### PR TITLE
Improve package's documentation, improve handling of headers, update lefthook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,25 @@ Subsequently, the date entry follows **YYYY-MM-DD** format in accordance with th
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+
 ## [v0.1.2] (2020-11-26)
 
+- **Updated**
+  - Improved GitHub Actions workflow upon each version update on each push made to `main` branch
+
+---
+
+## [v0.1.1] (2020-11-23)
+
+- **Added**
+  - Author metadata
+  - Automatic publishing on <https://pub.dev> through GitHub Actions
+
+- **Updated**
+  - Routing logic
+  - Package ocumentation
+
+---
 
 ## [v0.1.0] (2020-11-20)
 
@@ -36,5 +53,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Added**
   - The MIT License
 
-[v0.1.0]: https://github.com/lomsa-dev/http-mock-adapter/commit/25e45986b585c225c2fd6e795d0bc83325050506
-[v0.0.1]: https://github.com/lomsa-dev/http-mock-adapter/commit/447829b2969300e0ff7e9d6a7c6697cd5744b632
+[v0.1.2]: https://github.com/lomsa-dev/http-mock-adapter/compare/87c41f1758660b94efc1538de39fb04bb12c0b95...c0ab40ed59d3898ebf03d706b25ca8b91c2d065d
+[v0.1.1]: https://github.com/lomsa-dev/http-mock-adapter/compare/c3da8b18fb583cac0500f9899c4901f40fdf18e5...87c41f1758660b94efc1538de39fb04bb12c0b95
+[v0.1.0]: https://github.com/lomsa-dev/http-mock-adapter/compare/7d3ffbf4f85ae69327b1736f9268df24607d7ccb...c3da8b18fb583cac0500f9899c4901f40fdf18e5
+[v0.0.1]: https://github.com/lomsa-dev/http-mock-adapter/compare/447829b2969300e0ff7e9d6a7c6697cd5744b632...7d3ffbf4f85ae69327b1736f9268df24607d7ccb

--- a/README.md
+++ b/README.md
@@ -8,10 +8,7 @@ Dio HTTP mock adapter for Dart/Flutter (compatible with Mockito).
 
 Sometimes, testing classes which are dependent on [Dio](https://pub.dev/packages/dio) requests are really tricky and require lots of boilerplate, this is where [http_mock_adapter](https://pub.dev/packages/http_mock_adapter) comes in, to make [Dio](https://pub.dev/packages/dio) request testing more flexible than it has ever been. By simply defining requests with their methods and responses by using chains of our [DioAdapter](https://pub.dev/documentation/http_mock_adapter/latest/http_mock_adapter/DioAdapter-class.html) and replacing [Dio](https://pub.dev/packages/dio)'s [httpClientAdapter](https://pub.dev/documentation/dio/latest/dio/HttpClientAdapter-class.html) with your custom mocked adapter, you will be able to mock basically any request that [Dio](https://pub.dev/packages/dio) can support. More over, [http_mock_adapter](https://pub.dev/packages/http_mock_adapter) package, supports request mocking with interceptors which are created via DioInterceptor class, so instead of replacing [Dio](https://pub.dev/packages/dio)'s [httpClientAdapter](https://pub.dev/documentation/dio/latest/dio/HttpClientAdapter-class.html) you can add your mocked interceptor inside the [dio.interceptors](https://pub.dev/documentation/dio/latest/dio/Interceptors-class.html) list by using its [add method](https://api.dart.dev/dev/2.12.0-29.0.dev/dart-collection/ListMixin/add.html). you can find example in [examples](https://pub.dev/packages/http_mock_adapter/example) section of [http_mock_adapter](https://pub.dev/packages/http_mock_adapter) package
 
-Sometimes, testing classes which are dependent on [Dio](https://pub.dev/packages/dio) requests are really tricky and require lots of boilerplate, this is where [http_mock_adapter](https://pub.dev/packages/http_mock_adapter) comes in, to make [Dio](https://pub.dev/packages/dio) request testing more flexible than it has ever been. By simply defining requests with their methods and responses by using chains of our [DioAdapter](https://pub.dev/documentation/http_mock_adapter/latest/http_mock_adapter/DioAdapter-class.html) and replacing [Dio](https://pub.dev/packages/dio)'s [httpClientAdapter](https://pub.dev/documentation/dio/latest/dio/HttpClientAdapter-class.html) with your custom mocked adapter, you will be able to mock basically any request that [Dio](https://pub.dev/packages/dio) can support. More over, [http_mock_adapter](https://pub.dev/packages/http_mock_adapter) package, supports request mocking with interceptors which are created via DioInterceptor class, so instead of replacing [Dio](https://pub.dev/packages/dio)'s [httpClientAdapter](https://pub.dev/documentation/dio/latest/dio/HttpClientAdapter-class.html) you can add your mocked interceptor inside the [dio.interceptors](https://pub.dev/documentation/dio/latest/dio/Interceptors-class.html) list by using its [add method](https://api.dart.dev/dev/2.12.0-29.0.dev/dart-collection/ListMixin/add.html). you can find example in [examples](https://pub.dev/packages/http_mock_adapter/example) section of [http_mock_adapter](https://pub.dev/packages/http_mock_adapter)  package
-___
-
-
+---
 
 ## Usage
 
@@ -36,10 +33,10 @@ void main() async {
       .reply(200, {'message': 'Successfully mocked POST!'});
 
   final onGetResponse = await dio.get(path);
-  print(onGetResponse.data); // {message: Successfully mocked GET!}
+  print(onGetResponse.data); // {"message":"Successfully mocked GET!"}
 
   final onPostResponse = await dio.post(path);
-  print(onPostResponse.data); // {message: Successfully mocked POST!}
+  print(onPostResponse.data); // {"message":"Successfully mocked POST!"}
 }
 ```
 

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -2,12 +2,12 @@ pre-push:
   parallel: true
   commands:
     tests:
-      run: flutter test
+      run: dart test
 
 pre-commit:
   commands:
     pretty:
       glob: "*.dart"
-      run: flutter format {staged_files} && git add {staged_files}
+      run: dart format {staged_files} && git add {staged_files}
     linter:
-      run: flutter analyze
+      run: dart analyze

--- a/lib/src/adapters/dio_adapter.dart
+++ b/lib/src/adapters/dio_adapter.dart
@@ -29,13 +29,19 @@ class DioAdapter extends HttpClientAdapter
   /// adds an instance of [RequestMatcher] in [History.data].
   @override
   RequestHandler onRoute(String route, {Request request = const Request()}) {
-    final requestHandler = RequestHandler();
+    final requestHandler = RequestHandler<DioAdapter>();
 
     history.data.add(
       RequestMatcher(
         Request(
           route: route,
           method: request.method,
+          data: request.data,
+          queryParameters: request.queryParameters ?? const {},
+          headers: request.headers ??
+              {
+                Headers.contentTypeHeader: Headers.jsonContentType,
+              },
         ),
         requestHandler,
       ),

--- a/lib/src/history.dart
+++ b/lib/src/history.dart
@@ -17,20 +17,22 @@ class History {
 
   /// Getter for the current request invocation's intended [responseBody].
   ResponseBody Function(RequestOptions options) get responseBody => (options) {
-        options.headers = {
-          Headers.contentTypeHeader: [Headers.jsonContentType],
-        };
+        if (options.headers == null || options.headers.isEmpty) {
+          options.headers = {
+            Headers.contentTypeHeader: Headers.jsonContentType,
+          };
+        }
 
         data.forEach((element) {
           if (options.signature == element.request.signature) {
             _requestInvocationIndex = data.indexOf(element);
 
-            current.response =
+            current.responseBody =
                 requestHandler.requestMap[requestHandler.statusCode];
           }
         });
 
-        final responseBody = current.response;
+        final responseBody = current.responseBody;
 
         return responseBody;
       };

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -55,6 +55,12 @@ class DioInterceptor extends Interceptor
         Request(
           route: route,
           method: request.method,
+          data: request.data,
+          queryParameters: request.queryParameters ?? const {},
+          headers: request.headers ??
+              const {
+                Headers.contentTypeHeader: Headers.jsonContentType,
+              },
         ),
         requestHandler,
       ),
@@ -71,7 +77,7 @@ class DioInterceptor extends Interceptor
     responseBody.headers = responseBody.headers ?? {};
 
     final headers = Headers.fromMap(responseBody.headers ?? {});
-    headers.set(Headers.contentTypeHeader, [Headers.jsonContentType]);
+    headers.set(Headers.contentTypeHeader, Headers.jsonContentType);
 
     return Response(
       data: await DefaultTransformer().transformResponse(options, responseBody),
@@ -79,7 +85,7 @@ class DioInterceptor extends Interceptor
         responseBody.headers ??
             const {
               Headers.contentTypeHeader,
-              [Headers.jsonContentType],
+              Headers.jsonContentType,
             },
       ),
       isRedirect: responseBody.isRedirect,

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -19,7 +19,7 @@ class Request {
   final Map<String, dynamic> queryParameters;
 
   /// Headers to encompass content-types.
-  final Map<String, List<String>> headers;
+  final Map<String, dynamic> headers;
 
   const Request({
     this.route,
@@ -27,7 +27,7 @@ class Request {
     this.data,
     this.queryParameters = const {},
     this.headers = const {
-      Headers.contentTypeHeader: [Headers.jsonContentType],
+      Headers.contentTypeHeader: Headers.jsonContentType,
     },
   });
 
@@ -43,7 +43,7 @@ extension Signature on RequestOptions {
   String get signature => '$path/$method/$data/$queryParameters/$headers';
 }
 
-/// Matcher of [Request] and [response] based on route and [RequestHandler].
+/// Matcher of [Request] and [responseBody] based on route and [RequestHandler].
 class RequestMatcher {
   /// This is a request sent by the the client.
   final Request request;
@@ -51,13 +51,13 @@ class RequestMatcher {
   /// This is a request handler that processes requests.
   final RequestHandler requestHandler;
 
-  /// This is an artificial response to the request.
-  ResponseBody response;
+  /// This is an artificial response body to the request.
+  ResponseBody responseBody;
 
   RequestMatcher(
     this.request,
     this.requestHandler, {
-    this.response,
+    this.responseBody,
   });
 }
 
@@ -102,82 +102,97 @@ mixin RequestRouted {
 
   /// Takes in a route, requests with [RequestMethods.GET],
   /// and sets corresponding [RequestHandler].
-
-  AdapterRequest get onGet => (String route, {dynamic data, dynamic headers}) {
-        return onRoute(
-          route,
-          request: Request(
-            method: RequestMethods.GET,
-            data: data,
-            headers: headers,
-          ),
-        );
-      };
+  AdapterRequest get onGet => (
+        String route, {
+        dynamic data,
+        dynamic headers,
+      }) =>
+          onRoute(
+            route,
+            request: Request(
+              method: RequestMethods.GET,
+              data: data,
+              headers: headers,
+            ),
+          );
 
   /// Takes in a route, requests with [RequestMethods.HEAD],
   /// and sets corresponding [RequestHandler].
-  AdapterRequest get onHead => (String route, {dynamic data, dynamic headers}) {
-        return onRoute(
-          route,
-          request: Request(
-            method: RequestMethods.HEAD,
-            data: data,
-            headers: headers,
-          ),
-        );
-      };
+  AdapterRequest get onHead => (
+        String route, {
+        dynamic data,
+        dynamic headers,
+      }) =>
+          onRoute(
+            route,
+            request: Request(
+              method: RequestMethods.HEAD,
+              data: data,
+              headers: headers,
+            ),
+          );
 
   /// Takes in a route, requests with [RequestMethods.POST],
   /// and sets corresponding [RequestHandler].
-  AdapterRequest get onPost => (String route, {dynamic data, dynamic headers}) {
-        return onRoute(
-          route,
-          request: Request(
-            method: RequestMethods.POST,
-            data: data,
-            headers: headers,
-          ),
-        );
-      };
+  AdapterRequest get onPost => (
+        String route, {
+        dynamic data,
+        dynamic headers,
+      }) =>
+          onRoute(
+            route,
+            request: Request(
+              method: RequestMethods.POST,
+              data: data,
+              headers: headers,
+            ),
+          );
 
   /// Takes in a route, requests with [RequestMethods.PUT],
   /// and sets corresponding [RequestHandler].
-  AdapterRequest get onPut => (String route, {dynamic data, dynamic headers}) {
-        return onRoute(
-          route,
-          request: Request(
-            method: RequestMethods.PUT,
-            data: data,
-            headers: headers,
-          ),
-        );
-      };
+  AdapterRequest get onPut => (
+        String route, {
+        dynamic data,
+        dynamic headers,
+      }) =>
+          onRoute(
+            route,
+            request: Request(
+              method: RequestMethods.PUT,
+              data: data,
+              headers: headers,
+            ),
+          );
 
   /// Takes in a route, requests with [RequestMethods.DELETE],
   /// and sets corresponding [RequestHandler].
-  AdapterRequest get onDelete =>
-      (String route, {dynamic data, dynamic headers}) {
-        return onRoute(
-          route,
-          request: Request(
-            method: RequestMethods.DELETE,
-            data: data,
-            headers: headers,
-          ),
-        );
-      };
+  AdapterRequest get onDelete => (
+        String route, {
+        dynamic data,
+        dynamic headers,
+      }) =>
+          onRoute(
+            route,
+            request: Request(
+              method: RequestMethods.DELETE,
+              data: data,
+              headers: headers,
+            ),
+          );
 
   /// Takes in a route, requests with [RequestMethods.PATCH],
   /// and sets corresponding [RequestHandler].
-  AdapterRequest get onPatch =>
-      (String route, {dynamic data, dynamic headers}) {
-        return onRoute(
-          route,
-          request: Request(
-            method: RequestMethods.PATCH,
-            data: data,
-            headers: headers,
-          ),
-        );
-      };
+  AdapterRequest get onPatch => (
+        String route, {
+        dynamic data,
+        dynamic headers,
+      }) =>
+          onRoute(
+            route,
+            request: Request(
+              method: RequestMethods.PATCH,
+              data: data,
+              headers: headers,
+            ),
+          );
 }

--- a/test/http_mock_adapter_test.dart
+++ b/test/http_mock_adapter_test.dart
@@ -178,23 +178,39 @@ void main() {
 
         dio.httpClientAdapter = dioAdapter;
 
-        dioAdapter.onPost('/route', data: {'post': '201'}).reply(201, {
+        dioAdapter.onPost(
+          '/route',
+          data: {'post': '201'},
+          headers: {
+            Headers.contentTypeHeader: Headers.jsonContentType,
+            Headers.contentLengthHeader:
+                jsonEncode({'post': '201'}).toString().length.toString()
+          },
+        ).reply(201, {
           'message': 'Post!',
         });
 
-        response = await dio.post('/route');
+        response = await dio.post('/route', data: {'post': '201'});
 
         expect(jsonEncode({'message': 'Post!'}), response.data);
 
-        dioAdapter.onPatch('/route', data: {'patch': '404'}).reply(404, {
+        dioAdapter.onPatch(
+          '/route',
+          data: {'patch': '404'},
+          headers: {
+            Headers.contentTypeHeader: Headers.jsonContentType,
+            Headers.contentLengthHeader:
+                jsonEncode({'patch': '404'}).toString().length.toString()
+          },
+        ).reply(404, {
           'message': 'Patch!',
         });
 
-        response = await dio.patch('/route');
+        response = await dio.patch('/route', data: {'patch': '404'});
 
         expect(jsonEncode({'message': 'Patch!'}), response.data);
 
-        dioAdapter.onGet('/api', data: {'get': '200'}).reply(200, {
+        dioAdapter.onGet('/api').reply(200, {
           'message': 'Get!',
         });
 


### PR DESCRIPTION
## Description

- Attempt to improve package's documentation (README.md and CHANGELOG.md) by fixing lint errors, enriching CHANGELOG.md by linking commit comparisons based on package versions and remove duplicated paragraph from README.md;
- Made headers actually matter and set default headers for requests are made to contain content-type of JSON if no headers were specified;
- Lefthook ran `flutter` commands, however, the package now solely depends on `dart` and failed to run pre-commit and pre-push hooks.