### PR TITLE
Allow value matchers for data and headers in reqs.

### DIFF
--- a/lib/http_mock_adapter.dart
+++ b/lib/http_mock_adapter.dart
@@ -7,5 +7,6 @@ library http_mock_adapter;
 export 'src/adapters/dio_adapter.dart';
 export 'src/adapters/dio_adapter_mockito.dart';
 export 'src/interceptors/dio_interceptor.dart';
+export 'src/matchers/matcher.dart';
 export 'src/request.dart';
 export 'src/exceptions.dart';

--- a/lib/src/history.dart
+++ b/lib/src/history.dart
@@ -25,13 +25,20 @@ class History {
         }
 
         data.forEach((element) {
-          if (options.signature == element.request.signature) {
+          if (options.signature == element.request.signature ||
+              options.matchesRequest(element.request)) {
             _requestInvocationIndex = data.indexOf(element);
 
             current.responseBody =
                 requestHandler.requestMap[requestHandler.statusCode];
           }
         });
+
+        /// fail when a mocked route is not found for the request
+        if (_requestInvocationIndex == null || _requestInvocationIndex < 0) {
+          throw AssertionError(
+              'Could not find mock route matching request for ${options.signature}');
+        }
 
         final responseBody = current.responseBody;
 

--- a/lib/src/matchers/matcher.dart
+++ b/lib/src/matchers/matcher.dart
@@ -1,0 +1,55 @@
+abstract class Matcher {
+  bool matches(dynamic actual);
+}
+
+class Any extends Matcher {
+  @override
+  bool matches(dynamic actual) => true;
+
+  @override
+  String toString() => 'Any';
+}
+
+class AnyNumber extends Matcher {
+  final bool strict; // require strict numbers or not, default false
+
+  AnyNumber({this.strict = false});
+
+  @override
+  bool matches(dynamic actual) =>
+      actual is int ||
+      actual is double ||
+      (!strict &&
+          actual != null &&
+          actual is String &&
+          (int.tryParse(actual) is int || double.tryParse(actual) is double));
+
+  @override
+  String toString() => 'AnyNumber{strict: $strict}';
+}
+
+class RegExpMatcher extends Matcher {
+  final RegExp regexp;
+
+  RegExpMatcher({
+    String pattern,
+    bool multiline = false,
+    bool caseSensitive = false,
+    RegExp regexp,
+  }) : regexp = regexp ??
+            RegExp(
+              pattern,
+              multiLine: multiline,
+              caseSensitive: caseSensitive,
+            );
+
+  @override
+  bool matches(dynamic actual) =>
+      actual != null && actual is String && regexp.hasMatch(actual);
+
+  @override
+  String toString() => 'RegExpMatcher{regexp: $regexp}';
+}
+
+final anyValue = Any();
+final anyNumber = AnyNumber(); // defaults to not strict (will check strings)

--- a/test/matchers/any_number_test.dart
+++ b/test/matchers/any_number_test.dart
@@ -1,0 +1,37 @@
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var strict = AnyNumber(strict: true);
+  var notStrict = AnyNumber();
+
+  test('anyNumber not-strict', () {
+    expect(anyNumber.matches(1), true);
+    expect(anyNumber.matches('1'), true);
+    expect(anyNumber.matches('a'), false);
+    expect(anyNumber.matches(null), false);
+    expect(anyNumber.matches({}), false);
+    expect(anyNumber.matches([]), false);
+    expect(anyNumber.matches(Any()), false);
+  });
+
+  test('not strict', () {
+    expect(notStrict.matches(1), true);
+    expect(notStrict.matches('1'), true);
+    expect(notStrict.matches('a'), false);
+    expect(notStrict.matches(null), false);
+    expect(notStrict.matches({}), false);
+    expect(notStrict.matches([]), false);
+    expect(notStrict.matches(Any()), false);
+  });
+
+  test('strict', () {
+    expect(strict.matches(1), true);
+    expect(strict.matches('1'), false);
+    expect(strict.matches('a'), false);
+    expect(strict.matches(null), false);
+    expect(strict.matches({}), false);
+    expect(strict.matches([]), false);
+    expect(strict.matches(Any()), false);
+  });
+}

--- a/test/matchers/any_test.dart
+++ b/test/matchers/any_test.dart
@@ -1,0 +1,22 @@
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('anyValue default', () {
+    expect(anyValue.matches('a'), true);
+    expect(anyValue.matches(null), true);
+    expect(anyValue.matches(1), true);
+    expect(anyValue.matches({}), true);
+    expect(anyValue.matches([]), true);
+    expect(anyValue.matches(Any()), true);
+  });
+
+  test('any value', () {
+    expect(Any().matches('a'), true);
+    expect(Any().matches(null), true);
+    expect(Any().matches(1), true);
+    expect(Any().matches({}), true);
+    expect(Any().matches([]), true);
+    expect(Any().matches(Any()), true);
+  });
+}

--- a/test/matchers/regexp_matcher_test.dart
+++ b/test/matchers/regexp_matcher_test.dart
@@ -1,0 +1,33 @@
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('regexp', () {
+    expect(RegExpMatcher(regexp: RegExp(r'[0-9]')).matches('1'), true);
+    expect(RegExpMatcher(regexp: RegExp(r'[a-z]')).matches('a'), true);
+    expect(RegExpMatcher(regexp: RegExp(r'[a-z]+')).matches('abcdef'), true);
+    expect(RegExpMatcher(regexp: RegExp(r'[a-z]+')).matches('abcdef '), true);
+    expect(RegExpMatcher(regexp: RegExp(r'[a-z]+$')).matches('abcdef '), false);
+    expect(RegExpMatcher(regexp: RegExp(r'a')).matches(1), false);
+    expect(RegExpMatcher(regexp: RegExp(r'[0-9]')).matches(null), false);
+    expect(RegExpMatcher(regexp: RegExp(r'[0-9]')).matches({}), false);
+    expect(RegExpMatcher(regexp: RegExp(r'[0-9]')).matches([]), false);
+    expect(RegExpMatcher(regexp: RegExp(r'[0-9]')).matches(Any()), false);
+  });
+
+  test('pattern', () {
+    expect(RegExpMatcher(pattern: r'[0-9]').matches('1'), true);
+    expect(RegExpMatcher(pattern: r'[a-z]').matches('a'), true);
+    expect(
+        RegExpMatcher(pattern: r'[a-z]+', caseSensitive: false)
+            .matches('AbCdEf'),
+        true);
+    expect(RegExpMatcher(pattern: r'[a-z]+').matches('abcdef '), true);
+    expect(RegExpMatcher(pattern: r'[a-z]+$').matches('abcdef '), false);
+    expect(RegExpMatcher(pattern: r'a').matches(1), false);
+    expect(RegExpMatcher(pattern: r'[0-9]').matches(null), false);
+    expect(RegExpMatcher(pattern: r'[0-9]').matches({}), false);
+    expect(RegExpMatcher(pattern: r'[0-9]').matches([]), false);
+    expect(RegExpMatcher(pattern: r'[0-9]').matches(Any()), false);
+  });
+}

--- a/test/matches_request_test.dart
+++ b/test/matches_request_test.dart
@@ -1,0 +1,174 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+import 'package:test/test.dart';
+
+const String PATH = '/test';
+
+void main() {
+  group('Request Options matchers', () {
+    test('general truthy test', () {
+      /// these RequestOptions and Request properties are required defaults
+      var options = RequestOptions(
+        path: PATH,
+        method: 'GET',
+        contentType: Headers.jsonContentType, // necessary or is set to null
+        headers: {Headers.contentTypeHeader: Headers.jsonContentType},
+        queryParameters: {},
+      );
+
+      var req = Request(
+        route: PATH,
+        method: RequestMethods.GET,
+        queryParameters: {},
+      );
+
+      expect(options.matchesRequest(req), true);
+    });
+
+    group('matches', () {
+      RequestOptions options;
+
+      setUp(() {
+        options = RequestOptions(
+          path: PATH,
+          method: 'GET',
+          contentType: Headers.jsonContentType,
+          headers: {Headers.contentTypeHeader: Headers.jsonContentType},
+          queryParameters: {},
+        );
+      });
+
+      group('map', () {
+        test('exactly', () {
+          var a = {
+            'a': 'a',
+            'b': 'b',
+          };
+          var b = {
+            'a': 'a',
+            'b': 'b',
+          };
+
+          expect(options.matches(a, b), true);
+        });
+
+        test('uses matchers to validate', () {
+          var a = {
+            'a': 'a',
+            'b': 'b',
+            'c': '123',
+            'd': 123,
+          };
+          var b = {
+            'a': anyValue,
+            'b': 'b',
+            'c': anyNumber,
+            'd': anyNumber,
+          };
+
+          expect(options.matches(a, b), true);
+        });
+
+        test('uses matchers but does not validate', () {
+          var a = {
+            'a': 'a',
+            'b': 'b',
+            'c': '123A',
+            'd': 123,
+          };
+          var b = {
+            'a': anyValue,
+            'b': 'b',
+            'c': anyNumber,
+            'd': anyNumber,
+          };
+
+          expect(options.matches(a, b), false);
+        });
+      });
+
+      group('list', () {
+        test('exactly', () {
+          var a = ['a', 'b'];
+          var b = ['a', 'b'];
+
+          expect(options.matches(a, b), true);
+        });
+
+        test('uses matchers to validate', () {
+          var a = ['a', 'b', '123', 123];
+          var b = [anyValue, 'b', anyNumber, anyNumber];
+
+          expect(options.matches(a, b), true);
+        });
+
+        test('uses matchers but does not validate', () {
+          var a = ['a', 'b', '123A', 123];
+          var b = [anyValue, 'b', anyNumber, anyNumber];
+
+          expect(options.matches(a, b), false);
+        });
+      });
+
+      group('Dio request with matchers', () {
+        Dio dio;
+
+        Map<String, dynamic> data = {'message': 'Test!'};
+        const path = 'https://example.com';
+
+        Response<dynamic> response;
+        const statusCode = 200;
+        DioAdapter dioAdapter;
+
+        setUpAll(() {
+          dio = Dio();
+
+          dioAdapter = DioAdapter();
+
+          dio.httpClientAdapter = dioAdapter;
+        });
+
+        test('mocks requests via onPost() with matchers as intended', () async {
+          dioAdapter = DioAdapter();
+
+          dio.httpClientAdapter = dioAdapter;
+
+          dioAdapter.onPost(
+            '/post-any-data',
+            data: {
+              'any': anyValue,
+              'pattern': RegExpMatcher(pattern: 'TEST'),
+              'regexp': RegExpMatcher(regexp: RegExp(r'([a-z]{3} ?){3}')),
+              'strict': 'match',
+              'map': {
+                'a': anyValue,
+                'b': 'b',
+              },
+              'list': ['a', 'b'],
+            },
+            headers: {
+              'content-type': RegExpMatcher(pattern: 'application'),
+              'content-length': anyNumber,
+            },
+          ).reply(statusCode, data);
+
+          response = await dio.post('/post-any-data', data: {
+            'any': '201',
+            'pattern': 'this is a test with ',
+            'regexp': 'abc def hij',
+            'strict': 'match',
+            'map': {
+              'a': 'a',
+              'b': 'b',
+            },
+            'list': ['a', 'b'],
+          });
+
+          expect(jsonEncode({'message': 'Test!'}), response.data);
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
Requests require exact matching using a `signature` comparison. This restricts the usefulness of mocking since some data may not be possible to get exactly right. In my case I'm sending timestamp data. This provides some flexibility in how strictly the data and headers are matched.
