### PR TITLE
Allow routes to be string or pattern.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ void main() async {
   const path = 'https://example.com';
 
   dioAdapter
-      .onGet(path)
+      .onGet(path) // `path` can be either `String` or `RegExp`
       .reply(200, {'message': 'Successfully mocked GET!'})
       .onPost(path)
       .reply(200, {'message': 'Successfully mocked POST!'});

--- a/lib/src/adapters/dio_adapter.dart
+++ b/lib/src/adapters/dio_adapter.dart
@@ -28,7 +28,7 @@ class DioAdapter extends HttpClientAdapter
   /// Takes in [route], [request], sets corresponding [RequestHandler],
   /// adds an instance of [RequestMatcher] in [History.data].
   @override
-  RequestHandler onRoute(String route, {Request request = const Request()}) {
+  RequestHandler onRoute(dynamic route, {Request request = const Request()}) {
     final requestHandler = RequestHandler<DioAdapter>();
 
     history.data.add(

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -48,7 +48,7 @@ class DioInterceptor extends Interceptor
   /// Takes in route, request, sets corresponding [RequestHandler],
   /// adds an instance of [RequestMatcher] in [History.data].
   @override
-  RequestHandler onRoute(String route, {Request request = const Request()}) {
+  RequestHandler onRoute(dynamic route, {Request request = const Request()}) {
     final requestHandler = RequestHandler<DioInterceptor>();
 
     history.data.add(

--- a/lib/src/interfaces.dart
+++ b/lib/src/interfaces.dart
@@ -17,7 +17,7 @@ import 'package:http_mock_adapter/src/types.dart';
 /// implement this interface to provide good developer experience.
 abstract class AdapterInterface {
   AdapterRequest get onGet;
-  RequestHandler onRoute(String route, {Request request = const Request()});
+  RequestHandler onRoute(dynamic route, {Request request = const Request()});
   AdapterRequest get onHead;
   AdapterRequest get onPost;
   AdapterRequest get onPut;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -6,7 +6,7 @@ import 'package:http_mock_adapter/src/request.dart';
 
 /// Type for request chainers like onGet.
 typedef AdapterRequest = RequestHandler Function(
-  String route, {
+  dynamic route, {
   dynamic data,
   dynamic headers,
 });

--- a/test/adapters/dio_adapter_test.dart
+++ b/test/adapters/dio_adapter_test.dart
@@ -163,6 +163,15 @@ void main() {
         response = await dio.get('/api');
         expect({'message': 'Chain!'}, response.data);
       });
+
+      test('mocks route pattern', () async {
+        dioAdapter
+            .onGet(RegExp(r'/test-route/[0-9]{6}'))
+            .reply(200, {'message': 'Test!'});
+
+        response = await dio.get('/test-route/123456');
+        expect({'message': 'Test!'}, response.data);
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

It's not always advantageous to have the route be a strict string, this allows for the route to be a pattern resolving (#68).

Signed-off-by: Nick Campbell <nicholas.j.campbell@gmail.com>

