### PR TITLE
Null-safety and DIO 4.0.0 support

### DIFF
--- a/.github/workflows/dart-ci.yml
+++ b/.github/workflows/dart-ci.yml
@@ -19,7 +19,7 @@ jobs:
     # available. See https://hub.docker.com/r/google/dart/ for the available
     # images.
     container:
-      image: google/dart:beta
+      image: google/dart:latest
 
     steps:
       - name: Checkout the repository

--- a/.github/workflows/dart-ci.yml
+++ b/.github/workflows/dart-ci.yml
@@ -19,7 +19,7 @@ jobs:
     # available. See https://hub.docker.com/r/google/dart/ for the available
     # images.
     container:
-      image: google/dart:latest
+      image: google/dart:beta
 
     steps:
       - name: Checkout the repository

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dev_dependencies:
-  http_mock_adapter: ^0.1.5
+  http_mock_adapter: ^0.2.0
 ```
 
 ### Install it

--- a/example/main.dart
+++ b/example/main.dart
@@ -5,7 +5,7 @@ import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:test/test.dart';
 
 void main() async {
-  Dio dio;
+  late Dio dio;
 
   Map<String, dynamic> data;
 
@@ -16,14 +16,11 @@ void main() async {
   const path = 'https://example.com';
 
   group('DioAdapter', () {
-    DioAdapter dioAdapter;
+    late DioAdapter dioAdapter;
 
     setUpAll(() {
-      dio = Dio();
-
       dioAdapter = DioAdapter();
-
-      dio.httpClientAdapter = dioAdapter;
+      dio = Dio()..httpClientAdapter = dioAdapter;
     });
 
     test('mocks the data', () async {
@@ -55,7 +52,7 @@ void main() async {
   });
 
   group('DioInterceptor', () {
-    DioInterceptor dioInterceptor;
+    late DioInterceptor dioInterceptor;
 
     setUpAll(() {
       dio = Dio();
@@ -90,24 +87,27 @@ void main() async {
   });
 
   group('AdapterError/DioError', () {
-    DioAdapter dioAdapter;
+    DioAdapter? dioAdapter;
 
     setUpAll(() {
       dio = Dio();
 
       dioAdapter = DioAdapter();
 
-      dio.httpClientAdapter = dioAdapter;
+      dio.httpClientAdapter = dioAdapter!;
     });
 
     test('throws custom exception', () async {
       final dioError = DioError(
         error: {'message': 'Some beautiful error!'},
-        response: Response(statusCode: 500),
-        type: DioErrorType.RESPONSE,
+        response: Response(
+          statusCode: 500,
+          request: RequestOptions(path: '/foo'),
+        ),
+        type: DioErrorType.response,
       );
 
-      dioAdapter.onGet(
+      dioAdapter!.onGet(
         path,
         (request) => request.throws(500, dioError),
       );

--- a/example/main.dart
+++ b/example/main.dart
@@ -100,9 +100,10 @@ void main() async {
     test('throws custom exception', () async {
       final dioError = DioError(
         error: {'message': 'Some beautiful error!'},
+        requestOptions: RequestOptions(path: '/foo'),
         response: Response(
           statusCode: 500,
-          request: RequestOptions(path: '/foo'),
+          requestOptions: RequestOptions(path: '/foo'),
         ),
         type: DioErrorType.response,
       );

--- a/example/main.dart
+++ b/example/main.dart
@@ -87,14 +87,14 @@ void main() async {
   });
 
   group('AdapterError/DioError', () {
-    DioAdapter? dioAdapter;
+    late DioAdapter dioAdapter;
 
     setUpAll(() {
       dio = Dio();
 
       dioAdapter = DioAdapter();
 
-      dio.httpClientAdapter = dioAdapter!;
+      dio.httpClientAdapter = dioAdapter;
     });
 
     test('throws custom exception', () async {
@@ -107,7 +107,7 @@ void main() async {
         type: DioErrorType.response,
       );
 
-      dioAdapter!.onGet(
+      dioAdapter.onGet(
         path,
         (request) => request.throws(500, dioError),
       );

--- a/lib/http_mock_adapter.dart
+++ b/lib/http_mock_adapter.dart
@@ -1,12 +1,6 @@
-/// A collection of different HTTP adapters intended to mock HTTP responses.
-///
-/// Set one of the HTTP adapters as your HTTP client, define request structure,
-/// define mock data, invoke HTTP client and evaluate the result.
-library http_mock_adapter;
-
 export 'src/adapters/dio_adapter.dart';
 export 'src/adapters/dio_adapter_mockito.dart';
+export 'src/exceptions.dart' show AdapterError;
 export 'src/interceptors/dio_interceptor.dart';
 export 'src/matchers/matchers.dart';
 export 'src/request.dart' show MatchesRequest, Request, RequestMethods;
-export 'src/exceptions.dart' show AdapterError;

--- a/lib/src/adapters/dio_adapter.dart
+++ b/lib/src/adapters/dio_adapter.dart
@@ -1,10 +1,9 @@
 import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart';
 import 'package:http_mock_adapter/src/handlers/request_handler.dart';
+import 'package:http_mock_adapter/src/history.dart';
+import 'package:http_mock_adapter/src/request.dart';
 import 'package:http_mock_adapter/src/types.dart';
-
-import '../history.dart';
-import '../request.dart';
 
 /// [HttpClientAdapter] extension with data mocking and tracking functionality.
 class DioAdapter extends HttpClientAdapter with RequestRouted, Tracked {
@@ -41,7 +40,7 @@ class DioAdapter extends HttpClientAdapter with RequestRouted, Tracked {
   Future<ResponseBody> fetch(
     RequestOptions options,
     Stream<List<int>> requestStream,
-    Future cancelFuture,
+    Future? cancelFuture,
   ) async {
     dynamic responseBody = history.responseBody(options);
 

--- a/lib/src/adapters/dio_adapter.dart
+++ b/lib/src/adapters/dio_adapter.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart';
 import 'package:http_mock_adapter/src/handlers/request_handler.dart';
@@ -39,7 +41,7 @@ class DioAdapter extends HttpClientAdapter with RequestRouted, Tracked {
   @override
   Future<ResponseBody> fetch(
     RequestOptions options,
-    Stream<List<int>> requestStream,
+    Stream<Uint8List>? requestStream,
     Future? cancelFuture,
   ) async {
     dynamic responseBody = history.responseBody(options);

--- a/lib/src/adapters/dio_adapter.dart
+++ b/lib/src/adapters/dio_adapter.dart
@@ -47,7 +47,9 @@ class DioAdapter extends HttpClientAdapter with RequestRouted, Tracked {
     dynamic responseBody = history.responseBody(options);
 
     // throws error if response type is AdapterError
-    throwError(responseBody);
+    if (isError(responseBody)) {
+      throw responseBody as DioError;
+    }
 
     responseBody.headers = responseBody.headers ??
         const {

--- a/lib/src/adapters/dio_adapter_mockito.dart
+++ b/lib/src/adapters/dio_adapter_mockito.dart
@@ -1,6 +1,47 @@
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:http_mock_adapter/src/adapters/dio_adapter.dart';
+import 'package:http_mock_adapter/src/request.dart';
+import 'package:http_mock_adapter/src/types.dart';
 import 'package:mockito/mockito.dart';
 
-import '../../http_mock_adapter.dart';
-
 /// [Mock]ed version of [DioAdapter].
-class DioAdapterMockito extends Mock implements DioAdapter {}
+class DioAdapterMockito extends Mock implements DioAdapter {
+  @override
+  void onRoute(
+    dynamic route,
+    RequestHandlerCallback callback, {
+    Request request = const Request(),
+  }) =>
+      super.noSuchMethod(Invocation.method(#onRoute, [
+        route,
+        request,
+        callback,
+      ]));
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions? options,
+    Stream<List<int>>? requestStream,
+    Future? cancelFuture,
+  ) async =>
+      super.noSuchMethod(
+          Invocation.method(#fetch, [
+            options,
+            requestStream,
+            cancelFuture,
+          ]),
+          returnValue: Future.value(ResponseBody(
+            Stream.value(Uint8List(1)),
+            0,
+          )));
+
+  @override
+  void close({bool? force = false}) =>
+      super.noSuchMethod(Invocation.method(#close, [
+        force,
+      ]));
+}

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -47,19 +47,19 @@ class ThrowsException implements Exception {
 /// Wrapper of [Dio]'s [DioError] [Exception].
 class AdapterError extends DioError implements Responsable {
   AdapterError({
-    RequestOptions? request,
+    required RequestOptions requestOptions,
     Response? response,
     DioErrorType type = DioErrorType.other,
     dynamic error,
   }) : super(
-          request: request,
+          requestOptions: requestOptions,
           response: response,
           type: type,
           error: error,
         );
 
   static AdapterError from(DioError dioError) => AdapterError(
-        request: dioError.request,
+        requestOptions: dioError.requestOptions,
         response: dioError.response,
         type: dioError.type,
         error: dioError.error,

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -47,8 +47,8 @@ class ThrowsException implements Exception {
 /// Wrapper of [Dio]'s [DioError] [Exception].
 class AdapterError extends DioError implements Responsable {
   AdapterError({
-    RequestOptions request,
-    Response response,
+    RequestOptions? request,
+    Response? response,
     DioErrorType type = DioErrorType.other,
     dynamic error,
   }) : super(
@@ -59,9 +59,9 @@ class AdapterError extends DioError implements Responsable {
         );
 
   static AdapterError from(DioError dioError) => AdapterError(
-        request: dioError?.request,
-        response: dioError?.response,
-        type: dioError?.type,
-        error: dioError?.error,
+        request: dioError.request,
+        response: dioError.response,
+        type: dioError.type,
+        error: dioError.error,
       );
 }

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -49,7 +49,7 @@ class AdapterError extends DioError implements Responsable {
   AdapterError({
     RequestOptions request,
     Response response,
-    DioErrorType type = DioErrorType.DEFAULT,
+    DioErrorType type = DioErrorType.other,
     dynamic error,
   }) : super(
           request: request,

--- a/lib/src/handlers/request_handler.dart
+++ b/lib/src/handlers/request_handler.dart
@@ -10,7 +10,7 @@ import 'package:http_mock_adapter/src/response.dart';
 /// The handler of requests sent by clients.
 class RequestHandler<T> {
   /// An HTTP status code such as - `200`, `404`, `500`, etc.
-  int statusCode;
+  late int statusCode;
 
   /// Map of <[statusCode], [Responsable]>.
   final Map<int, Responsable Function()> requestMap = {};
@@ -23,8 +23,8 @@ class RequestHandler<T> {
     Map<String, List<String>> headers = const {
       Headers.contentTypeHeader: [Headers.jsonContentType],
     },
-    String statusMessage,
-    bool isRedirect,
+    String? statusMessage,
+    bool isRedirect = false,
   }) {
     this.statusCode = statusCode;
 

--- a/lib/src/handlers/request_handler.dart
+++ b/lib/src/handlers/request_handler.dart
@@ -41,8 +41,7 @@ class RequestHandler<T> {
   /// and returns [DioAdapter] or [DioInterceptor],
   /// the latter which is utilized for method chaining.
   void throws(int statusCode, DioError dioError) {
-    if (dioError.runtimeType != DioError &&
-        dioError.runtimeType != AdapterError) {
+    if (!(dioError is DioError) && !(dioError is AdapterError)) {
       throw ThrowsException();
     }
 

--- a/lib/src/history.dart
+++ b/lib/src/history.dart
@@ -5,15 +5,15 @@ import 'package:http_mock_adapter/src/types.dart';
 /// Intended to keep track of request history.
 class History {
   /// The index of request invocations.
-  int _requestInvocationIndex;
+  int? _requestInvocationIndex;
 
-  RequestMatcher requestMatcher;
+  RequestMatcher? requestMatcher;
 
   /// The history content containing [RequestMatcher] objects.
   List<RequestMatcher> data = [];
 
   /// Gets current [RequestMatcher].
-  RequestMatcher get current => data[_requestInvocationIndex];
+  RequestMatcher get current => data[_requestInvocationIndex!];
 
   /// Getter for the current request invocation's intended [responseBody].
   AdapterResponseBody get responseBody => (options) {
@@ -28,13 +28,13 @@ class History {
         });
 
         // Fail when a mocked route is not found for the request.
-        if (_requestInvocationIndex == null || _requestInvocationIndex < 0) {
+        if (_requestInvocationIndex == null || _requestInvocationIndex! < 0) {
           throw AssertionError(
             'Could not find mocked route matching request for ${options.signature}',
           );
         }
 
-        return current.responseBody();
+        return current.responseBody!();
       };
 
   /// Getter for the current request invocation's [RequestHandler].

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -65,12 +65,7 @@ class DioInterceptor extends Interceptor with Tracked, RequestRouted {
     // Throws error if response type is DioError.
     throwError(response);
 
-    AdapterResponse responseBody = response;
-
-    responseBody.headers = responseBody.headers ??
-        const {
-          Headers.contentTypeHeader: [Headers.jsonContentType],
-        };
+    final responseBody = response as AdapterResponse;
 
     return Response(
       data: await DefaultTransformer().transformResponse(options, responseBody),

--- a/lib/src/interfaces.dart
+++ b/lib/src/interfaces.dart
@@ -57,7 +57,7 @@ abstract class AdapterInterface {
     dynamic data,
     dynamic headers,
   });
-  void throwError(Responsable response);
+  bool isError(Responsable response);
 }
 
 /// Top level interface for [Dio]'s [ResponseBody] and also [Dio]'s [DioError].

--- a/lib/src/matchers/matchers.dart
+++ b/lib/src/matchers/matchers.dart
@@ -38,8 +38,8 @@ class Matchers {
   /// It is mainly used as a shorthand for matching via [RegExp].
   static RegExpMatcher pattern(
     String pattern, {
-    bool multiLine,
-    bool caseSensitive,
+    bool? multiLine,
+    bool? caseSensitive,
   }) =>
       RegExpMatcher(
         pattern: pattern,

--- a/lib/src/matchers/regexp.dart
+++ b/lib/src/matchers/regexp.dart
@@ -7,13 +7,13 @@ class RegExpMatcher extends Matcher {
   final RegExp regExp;
 
   RegExpMatcher({
-    String pattern,
+    String? pattern,
     bool multiLine = false,
     bool caseSensitive = false,
-    RegExp regExp,
+    RegExp? regExp,
   }) : regExp = regExp ??
             RegExp(
-              pattern,
+              pattern!,
               multiLine: multiLine,
               caseSensitive: caseSensitive,
             );

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -23,7 +23,7 @@ class Request {
   final Map<String, dynamic> queryParameters;
 
   /// Headers to encompass content-types.
-  final Map<String, dynamic> headers;
+  final Map<String, dynamic>? headers;
 
   const Request({
     this.route,
@@ -66,7 +66,7 @@ extension Signature on RequestOptions {
 /// by [DioInterceptor].
 String sortedData(dynamic data) {
   if (data is Map) {
-    final sortedKeys = data.keys.toList()..sort();
+    final dynamic sortedKeys = data.keys.toList()..sort();
 
     data = {for (final sortedKey in sortedKeys) sortedKey: data[sortedKey]};
   }
@@ -86,7 +86,7 @@ extension MatchesRequest on RequestOptions {
     final queryParametersMatched =
         matches(queryParameters, request.queryParameters);
 
-    // dio adds headers to the requeset when none aare specified
+    // dio adds headers to the request when none aare specified
     final requestHeaders = request.headers ??
         {
           Headers.contentTypeHeader: Headers.jsonContentType,
@@ -189,7 +189,7 @@ class RequestMatcher {
   final RequestHandler requestHandler;
 
   /// This is an artificial response body to the request.
-  Responsable Function() responseBody;
+  Responsable Function()? responseBody;
 
   RequestMatcher(
     this.request,
@@ -350,7 +350,7 @@ mixin RequestRouted implements AdapterInterface {
   @override
   void throwError(Responsable response) {
     if (response.runtimeType == AdapterError) {
-      AdapterError error = response;
+      AdapterError error = response as AdapterError;
 
       throw error;
     }

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -39,24 +39,14 @@ class Request {
             };
 
   /// [signature] is the [String] representation of the [Request]'s body.
-  String get signature =>
-      '$route/${method.value}/' +
-      sortedData(data) +
-      '/' +
-      sortedData(queryParameters) +
-      '/$headers';
+  String get signature => '$route/${method.value}/' + sortedData(data) + '/' + sortedData(queryParameters) + '/$headers';
 }
 
 /// [Signature] extension method adds [signature] getter to [RequestOptions]
 /// in order to easily retrieve [Request]'s body representation as [String].
 extension Signature on RequestOptions {
   /// [signature] is the [String] representation of the [RequestOptions]'s body.
-  String get signature =>
-      '$path/$method/' +
-      sortedData(data) +
-      '/' +
-      sortedData(queryParameters) +
-      '/$headers';
+  String get signature => '$path/$method/' + sortedData(data) + '/' + sortedData(queryParameters) + '/$headers';
 }
 
 /// [sortedData] sorts request [Signature]'s and [Request.signature]'s 'data'
@@ -85,22 +75,13 @@ extension MatchesRequest on RequestOptions {
     final routeMatched = doesRouteMatch(path, request.route);
     final requestBodyMatched = matches(data, request.data);
 
-    final queryParametersMatched =
-        matches(queryParameters, request.queryParameters);
+    final queryParametersMatched = matches(queryParameters, request.queryParameters);
 
     // dio adds headers to the request when none aare specified
-    final requestHeaders = request.headers ??
-        {
-          Headers.contentTypeHeader: Headers.jsonContentType,
-          Headers.contentLengthHeader: Matchers.number
-        };
+    final requestHeaders = request.headers ?? {Headers.contentTypeHeader: Headers.jsonContentType, Headers.contentLengthHeader: Matchers.number};
     final headersMatched = matches(headers, requestHeaders);
 
-    if (!routeMatched ||
-        method != request.method.value ||
-        !requestBodyMatched ||
-        !queryParametersMatched ||
-        !headersMatched) {
+    if (!routeMatched || method != request.method.value || !requestBodyMatched || !queryParametersMatched || !headersMatched) {
       return false;
     }
 
@@ -242,7 +223,7 @@ mixin RequestRouted implements AdapterInterface {
     dynamic route,
     RequestHandlerCallback callback, {
     dynamic data,
-    Map<String, dynamic> queryParameters,
+    Map<String, dynamic> queryParameters = const {},
     dynamic headers,
   }) =>
       onRoute(
@@ -263,7 +244,7 @@ mixin RequestRouted implements AdapterInterface {
     dynamic route,
     RequestHandlerCallback callback, {
     dynamic data,
-    Map<String, dynamic> queryParameters,
+    Map<String, dynamic> queryParameters = const {},
     dynamic headers,
   }) =>
       onRoute(
@@ -284,7 +265,7 @@ mixin RequestRouted implements AdapterInterface {
     dynamic route,
     RequestHandlerCallback callback, {
     dynamic data,
-    Map<String, dynamic> queryParameters,
+    Map<String, dynamic> queryParameters = const {},
     dynamic headers,
   }) =>
       onRoute(
@@ -305,7 +286,7 @@ mixin RequestRouted implements AdapterInterface {
     dynamic route,
     RequestHandlerCallback callback, {
     dynamic data,
-    Map<String, dynamic> queryParameters,
+    Map<String, dynamic> queryParameters = const {},
     dynamic headers,
   }) =>
       onRoute(
@@ -326,7 +307,7 @@ mixin RequestRouted implements AdapterInterface {
     dynamic route,
     RequestHandlerCallback callback, {
     dynamic data,
-    Map<String, dynamic> queryParameters,
+    Map<String, dynamic> queryParameters = const {},
     dynamic headers,
   }) =>
       onRoute(
@@ -347,7 +328,7 @@ mixin RequestRouted implements AdapterInterface {
     dynamic route,
     RequestHandlerCallback callback, {
     dynamic data,
-    Map<String, dynamic> queryParameters,
+    Map<String, dynamic> queryParameters = const {},
     dynamic headers,
   }) =>
       onRoute(

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -349,10 +349,8 @@ mixin RequestRouted implements AdapterInterface {
 
   @override
   void throwError(Responsable response) {
-    if (response.runtimeType == AdapterError) {
-      AdapterError error = response as AdapterError;
-
-      throw error;
+    if (response is AdapterError) {
+      throw response;
     }
   }
 }

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -39,14 +39,24 @@ class Request {
             };
 
   /// [signature] is the [String] representation of the [Request]'s body.
-  String get signature => '$route/${method.value}/' + sortedData(data) + '/' + sortedData(queryParameters) + '/$headers';
+  String get signature =>
+      '$route/${method.value}/' +
+      sortedData(data) +
+      '/' +
+      sortedData(queryParameters) +
+      '/$headers';
 }
 
 /// [Signature] extension method adds [signature] getter to [RequestOptions]
 /// in order to easily retrieve [Request]'s body representation as [String].
 extension Signature on RequestOptions {
   /// [signature] is the [String] representation of the [RequestOptions]'s body.
-  String get signature => '$path/$method/' + sortedData(data) + '/' + sortedData(queryParameters) + '/$headers';
+  String get signature =>
+      '$path/$method/' +
+      sortedData(data) +
+      '/' +
+      sortedData(queryParameters) +
+      '/$headers';
 }
 
 /// [sortedData] sorts request [Signature]'s and [Request.signature]'s 'data'
@@ -75,13 +85,22 @@ extension MatchesRequest on RequestOptions {
     final routeMatched = doesRouteMatch(path, request.route);
     final requestBodyMatched = matches(data, request.data);
 
-    final queryParametersMatched = matches(queryParameters, request.queryParameters);
+    final queryParametersMatched =
+        matches(queryParameters, request.queryParameters);
 
     // dio adds headers to the request when none aare specified
-    final requestHeaders = request.headers ?? {Headers.contentTypeHeader: Headers.jsonContentType, Headers.contentLengthHeader: Matchers.number};
+    final requestHeaders = request.headers ??
+        {
+          Headers.contentTypeHeader: Headers.jsonContentType,
+          Headers.contentLengthHeader: Matchers.number
+        };
     final headersMatched = matches(headers, requestHeaders);
 
-    if (!routeMatched || method != request.method.value || !requestBodyMatched || !queryParametersMatched || !headersMatched) {
+    if (!routeMatched ||
+        method != request.method.value ||
+        !requestBodyMatched ||
+        !queryParametersMatched ||
+        !headersMatched) {
       return false;
     }
 

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -348,9 +348,5 @@ mixin RequestRouted implements AdapterInterface {
       );
 
   @override
-  void throwError(Responsable response) {
-    if (response is AdapterError) {
-      throw response;
-    }
-  }
+  bool isError(Responsable response) => response is AdapterError;
 }

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -1,17 +1,18 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:dio/dio.dart';
 import 'package:http_mock_adapter/src/interfaces.dart';
-import 'dart:typed_data';
-import 'dart:convert';
 
 /// Wrapper of [Dio]'s [ResponseBody].
 class AdapterResponse extends ResponseBody implements Responsable {
   AdapterResponse(
     Stream<Uint8List> stream,
     int statusCode, {
-    Map<String, List<String>> headers,
-    String statusMessage,
-    bool isRedirect,
-    List<RedirectRecord> redirects,
+    required Map<String, List<String>> headers,
+    String? statusMessage,
+    required bool isRedirect,
+    List<RedirectRecord>? redirects,
   }) : super(
           stream,
           statusCode,
@@ -24,9 +25,9 @@ class AdapterResponse extends ResponseBody implements Responsable {
   static AdapterResponse from(
     String text,
     int statusCode, {
-    Map<String, List<String>> headers,
-    String statusMessage,
-    bool isRedirect,
+    required Map<String, List<String>> headers,
+    String? statusMessage,
+    required bool isRedirect,
   }) =>
       AdapterResponse(
         Stream.fromIterable(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,19 +2,19 @@ name: http_mock_adapter
 description: HTTP mock adapter for Dio & Mockito. By simply defining requests
   and corresponding responses through predefined adapters, you will be able to
   mock requests sent via Dio.
-version: 0.1.5
+version: 1.0.0-nullsafety.1
 homepage: https://lomsa.com
 repository: https://github.com/lomsa-dev/http-mock-adapter
 issue_tracker: https://github.com/lomsa-dev/http-mock-adapter/issues
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
-  dio: ^3.0.10
-  meta: ^1.2.3
-  mockito: ^4.1.3
+  dio: ">=4.0.0-beta3 <5.0.0"
+  meta: ^1.3.0
+  mockito: ^5.0.0
 
 dev_dependencies:
-  pedantic: ^1.9.0
-  test: ^1.15.7
+  pedantic: ^1.10.0
+  test: ^1.16.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  dio: '>=4.0.0-prev1 <5.0.0'
+  dio: '>=4.0.0-prev2 <5.0.0'
   mockito: ^5.0.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,11 +8,10 @@ repository: https://github.com/lomsa-dev/http-mock-adapter
 issue_tracker: https://github.com/lomsa-dev/http-mock-adapter/issues
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  dio: ">=4.0.0-beta3 <5.0.0"
-  meta: ^1.3.0
+  dio: '>=4.0.0-beta3 <5.0.0'
   mockito: ^5.0.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,10 @@ repository: https://github.com/lomsa-dev/http-mock-adapter
 issue_tracker: https://github.com/lomsa-dev/http-mock-adapter/issues
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  dio: '>=4.0.0-beta3 <5.0.0'
+  dio: '>=4.0.0-beta6 <5.0.0'
   mockito: ^5.0.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  dio: '>=4.0.0-beta6 <5.0.0'
+  dio: '>=4.0.0-prev1 <5.0.0'
   mockito: ^5.0.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: http_mock_adapter
 description: HTTP mock adapter for Dio & Mockito. By simply defining requests
   and corresponding responses through predefined adapters, you will be able to
   mock requests sent via Dio.
-version: 1.0.0-nullsafety.1
+version: 0.2.0
 homepage: https://lomsa.com
 repository: https://github.com/lomsa-dev/http-mock-adapter
 issue_tracker: https://github.com/lomsa-dev/http-mock-adapter/issues

--- a/test/adapters/dio_adapter_mockito_test.dart
+++ b/test/adapters/dio_adapter_mockito_test.dart
@@ -6,17 +6,14 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 void main() {
-  Dio dio;
-  DioAdapterMockito dioAdapterMockito;
+  late Dio dio;
+  late DioAdapterMockito dioAdapterMockito;
 
   Response<dynamic> response;
 
   setUpAll(() {
-    dio = Dio();
-
     dioAdapterMockito = DioAdapterMockito();
-
-    dio.httpClientAdapter = dioAdapterMockito;
+    dio = Dio()..httpClientAdapter = dioAdapterMockito;
   });
 
   group('DioAdapterMockito', () {

--- a/test/adapters/dio_adapter_test.dart
+++ b/test/adapters/dio_adapter_test.dart
@@ -3,8 +3,8 @@ import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:test/test.dart';
 
 void main() {
-  Dio dio;
-  DioAdapter dioAdapter;
+  late Dio dio;
+  late DioAdapter dioAdapter;
 
   Response<dynamic> response;
 
@@ -17,11 +17,8 @@ void main() {
   const statusCode = 200;
 
   setUp(() {
-    dio = Dio();
-
     dioAdapter = DioAdapter();
-
-    dio.httpClientAdapter = dioAdapter;
+    dio = Dio()..httpClientAdapter = dioAdapter;
   });
 
   group('DioAdapter', () {
@@ -38,7 +35,10 @@ void main() {
       test('Test that throws raises custom exception', () async {
         final dioError = DioError(
           error: {'message': 'error'},
-          response: Response(statusCode: 500),
+          response: Response(
+            statusCode: 500,
+            request: RequestOptions(path: '/foo'),
+          ),
           type: DioErrorType.response,
         );
 

--- a/test/adapters/dio_adapter_test.dart
+++ b/test/adapters/dio_adapter_test.dart
@@ -53,7 +53,10 @@ void main() {
           () async => await dio.get(path),
           throwsA(
             predicate(
-              (DioError error) => error is DioError && error is AdapterError && error.message == dioError.error.toString(),
+              (DioError error) =>
+                  error is DioError &&
+                  error is AdapterError &&
+                  error.message == dioError.error.toString(),
             ),
           ),
         );

--- a/test/adapters/dio_adapter_test.dart
+++ b/test/adapters/dio_adapter_test.dart
@@ -37,7 +37,7 @@ void main() {
           error: {'message': 'error'},
           response: Response(
             statusCode: 500,
-            request: RequestOptions(path: '/foo'),
+            request: RequestOptions(path: path),
           ),
           type: DioErrorType.response,
         );
@@ -53,10 +53,7 @@ void main() {
           () async => await dio.get(path),
           throwsA(
             predicate(
-              (DioError error) =>
-                  error is DioError &&
-                  error is AdapterError &&
-                  error.message == dioError.error.toString(),
+              (DioError error) => error is DioError && error is AdapterError && error.message == dioError.error.toString(),
             ),
           ),
         );

--- a/test/adapters/dio_adapter_test.dart
+++ b/test/adapters/dio_adapter_test.dart
@@ -39,7 +39,7 @@ void main() {
         final dioError = DioError(
           error: {'message': 'error'},
           response: Response(statusCode: 500),
-          type: DioErrorType.RESPONSE,
+          type: DioErrorType.response,
         );
 
         dioAdapter.onGet(

--- a/test/adapters/dio_adapter_test.dart
+++ b/test/adapters/dio_adapter_test.dart
@@ -35,9 +35,10 @@ void main() {
       test('Test that throws raises custom exception', () async {
         final dioError = DioError(
           error: {'message': 'error'},
+          requestOptions: RequestOptions(path: path),
           response: Response(
             statusCode: 500,
-            request: RequestOptions(path: path),
+            requestOptions: RequestOptions(path: path),
           ),
           type: DioErrorType.response,
         );

--- a/test/history_test.dart
+++ b/test/history_test.dart
@@ -5,17 +5,14 @@ import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:test/test.dart';
 
 void main() {
-  Dio dio;
-  DioAdapter dioAdapter;
+  late Dio dio;
+  late DioAdapter dioAdapter;
 
   const path = 'https://example.com';
 
   setUpAll(() {
-    dio = Dio();
-
     dioAdapter = DioAdapter();
-
-    dio.httpClientAdapter = dioAdapter;
+    dio = Dio()..httpClientAdapter = dioAdapter;
   });
 
   group('History', () {

--- a/test/interceptors/dio_interceptor_test.dart
+++ b/test/interceptors/dio_interceptor_test.dart
@@ -46,7 +46,7 @@ void main() {
               type: type,
               response: Response(
                 statusCode: 500,
-                request: RequestOptions(path: '/foo'),
+                request: RequestOptions(path: path),
               ),
               error: error,
             ),
@@ -54,18 +54,13 @@ void main() {
         );
 
         // Checking that exception type can match `AdapterError` type too.
-        expect(() async => await dio.get(path),
-            throwsA(TypeMatcher<AdapterError>()));
+        expect(() async => await dio.get(path), throwsA(TypeMatcher<AdapterError>()));
 
         // Checking that exception type can match `DioError` type too.
-        expect(
-            () async => await dio.get(path), throwsA(TypeMatcher<DioError>()));
+        expect(() async => await dio.get(path), throwsA(TypeMatcher<DioError>()));
 
         // Checking the type and the message of the exception.
-        expect(
-            () async => await dio.get(path),
-            throwsA(predicate(
-                (DioError e) => e is DioError && e.message == error)));
+        expect(() async => await dio.get(path), throwsA(predicate((DioError e) => e is DioError && e.message == error)));
       });
 
       test('mocks requests via onRoute() as intended', () async {

--- a/test/interceptors/dio_interceptor_test.dart
+++ b/test/interceptors/dio_interceptor_test.dart
@@ -54,13 +54,18 @@ void main() {
         );
 
         // Checking that exception type can match `AdapterError` type too.
-        expect(() async => await dio.get(path), throwsA(TypeMatcher<AdapterError>()));
+        expect(() async => await dio.get(path),
+            throwsA(TypeMatcher<AdapterError>()));
 
         // Checking that exception type can match `DioError` type too.
-        expect(() async => await dio.get(path), throwsA(TypeMatcher<DioError>()));
+        expect(
+            () async => await dio.get(path), throwsA(TypeMatcher<DioError>()));
 
         // Checking the type and the message of the exception.
-        expect(() async => await dio.get(path), throwsA(predicate((DioError e) => e is DioError && e.message == error)));
+        expect(
+            () async => await dio.get(path),
+            throwsA(predicate(
+                (DioError e) => e is DioError && e.message == error)));
       });
 
       test('mocks requests via onRoute() as intended', () async {

--- a/test/interceptors/dio_interceptor_test.dart
+++ b/test/interceptors/dio_interceptor_test.dart
@@ -44,9 +44,10 @@ void main() {
             500,
             AdapterError(
               type: type,
+              requestOptions: RequestOptions(path: path),
               response: Response(
                 statusCode: 500,
-                request: RequestOptions(path: path),
+                requestOptions: RequestOptions(path: path),
               ),
               error: error,
             ),

--- a/test/interceptors/dio_interceptor_test.dart
+++ b/test/interceptors/dio_interceptor_test.dart
@@ -33,7 +33,7 @@ void main() {
 
     group('RequestRouted', () {
       test('Test that throws raises custom exception', () async {
-        const type = DioErrorType.RESPONSE;
+        const type = DioErrorType.response;
         const error = 'Some beautiful error';
 
         // Building request to throw the DioError exception

--- a/test/interceptors/dio_interceptor_test.dart
+++ b/test/interceptors/dio_interceptor_test.dart
@@ -3,7 +3,7 @@ import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:test/test.dart';
 
 void main() {
-  Dio dio;
+  late Dio dio;
 
   const data = {'message': 'Test!'};
   const path = 'https://example.com';
@@ -12,7 +12,7 @@ void main() {
   const statusCode = 200;
 
   group('DioInterceptor', () {
-    DioInterceptor dioInterceptor;
+    late DioInterceptor dioInterceptor;
 
     setUpAll(() {
       dio = Dio();
@@ -44,7 +44,10 @@ void main() {
             500,
             AdapterError(
               type: type,
-              response: Response(statusCode: 500),
+              response: Response(
+                statusCode: 500,
+                request: RequestOptions(path: '/foo'),
+              ),
               error: error,
             ),
           ),

--- a/test/matches_request_test.dart
+++ b/test/matches_request_test.dart
@@ -27,7 +27,7 @@ void main() {
     });
 
     group('matches', () {
-      RequestOptions options;
+      late RequestOptions options;
 
       setUp(() {
         options = RequestOptions(
@@ -125,7 +125,7 @@ void main() {
       });
 
       group('Dio request with matchers', () {
-        Dio dio;
+        late Dio dio;
 
         const data = {'message': 'Test!'};
 

--- a/test/matches_request_test.dart
+++ b/test/matches_request_test.dart
@@ -11,9 +11,7 @@ void main() {
       final options = RequestOptions(
         path: path,
         method: 'GET',
-        // Necessary or is set to null.
         contentType: Headers.jsonContentType,
-        headers: {Headers.contentTypeHeader: Headers.jsonContentType},
         queryParameters: {},
       );
 
@@ -34,7 +32,6 @@ void main() {
           path: path,
           method: 'GET',
           contentType: Headers.jsonContentType,
-          headers: {Headers.contentTypeHeader: Headers.jsonContentType},
           queryParameters: {},
         );
       });


### PR DESCRIPTION
## Description

This PR adds null-safety and DIO 4.0.0 support. Fixes #67

This PR is based on #82 so that one needs to be merge first, afterwards I can rebase. That will make the diff clearer. 

This should be published as `1.0.0` or `1.0.0-nullsafety.1` preview.

 CC @LukaGiorgadze @GiorgiBeriashvili @campfire5