### PR TITLE
Update to v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [v0.1.6] (2021-03-30)
+
+- **Added**
+  - Ability to match routes based on pattern;
+  - Tests;
+  - Straightforward way to reset history;
+  - Query parameters to `RequestRouted`'s methods.
+
+- **Fixed**
+  - `Response` problems regarding closed streams.
+
+- **Removed**
+  - Singleton instances of `DioAdapter` and `DioInterceptor`;
+
+- **Updated**
+  - `Match` variable names;
+  - `matches` function to include null check;
+  - `.gitignore` now includes `pubspec.lock`;
+  - Request mock method chaining variation.
+
+---
+
 ## [v0.1.5] (2021-01-07)
 
 - **Added**
@@ -102,6 +124,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Added**
   - The MIT License.
 
+[v0.1.6]: https://github.com/lomsa-dev/http-mock-adapter/compare/ff0b5b1c9d976e774002f3176fa0b6acd193c715...24cafff5236f8cc7d52a05529751ac47abd895ff
 [v0.1.5]: https://github.com/lomsa-dev/http-mock-adapter/compare/19310519550fc6402eb760ee5f3ef0757d187b89...ff0b5b1c9d976e774002f3176fa0b6acd193c715
 [v0.1.4]: https://github.com/lomsa-dev/http-mock-adapter/compare/21f5d211b8a798206fe4a727bff3a60eb8e3dcaf...19310519550fc6402eb760ee5f3ef0757d187b89
 [v0.1.3]: https://github.com/lomsa-dev/http-mock-adapter/compare/c0ab40ed59d3898ebf03d706b25ca8b91c2d065d...21f5d211b8a798206fe4a727bff3a60eb8e3dcaf

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dev_dependencies:
-  http_mock_adapter: ^0.1.5
+  http_mock_adapter: ^0.1.6
 ```
 
 ### Install it

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: http_mock_adapter
 description: HTTP mock adapter for Dio & Mockito. By simply defining requests
   and corresponding responses through predefined adapters, you will be able to
   mock requests sent via Dio.
-version: 0.1.5
+version: 0.1.6
 homepage: https://lomsa.com
 repository: https://github.com/lomsa-dev/http-mock-adapter
 issue_tracker: https://github.com/lomsa-dev/http-mock-adapter/issues


### PR DESCRIPTION
## Description

This is a release candidate for version `0.1.6` of the package.

Please see the [CHANGELOG.md](https://github.com/lomsa-dev/http-mock-adapter/blob/f2ea55ed40388c52baeb6f6ca1f68895c7b60214/CHANGELOG.md) file for brief summary of changes.