### PR TITLE
Fix mocking non-JSON response data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ pubspec.lock
 !**/ios/**/default.mode2v3
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
+
+# Code coverage
+/coverage

--- a/lib/src/handlers/request_handler.dart
+++ b/lib/src/handlers/request_handler.dart
@@ -27,9 +27,12 @@ class RequestHandler<T> {
     bool isRedirect = false,
   }) {
     this.statusCode = statusCode;
+    final isJson =
+        headers[Headers.contentTypeHeader]?.contains(Headers.jsonContentType) ??
+            false;
 
     requestMap[this.statusCode] = () => AdapterResponse.from(
-          jsonEncode(data),
+          isJson ? jsonEncode(data) : data,
           this.statusCode,
           headers: headers,
           statusMessage: statusMessage,

--- a/test/handlers/request_handler_test.dart
+++ b/test/handlers/request_handler_test.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:http_mock_adapter/src/exceptions.dart';
+import 'package:http_mock_adapter/src/handlers/request_handler.dart';
+import 'package:http_mock_adapter/src/response.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RequestHandler', () {
+    late RequestHandler requestHandler;
+
+    setUp(() {
+      requestHandler = RequestHandler();
+    });
+
+    test('sets response data for a status with JSON by default', () async {
+      const statusCode = HttpStatus.ok;
+      const inputData = {'data': 'OK'};
+
+      requestHandler.reply(
+        statusCode,
+        inputData,
+      );
+
+      expect(requestHandler.statusCode, statusCode);
+      final statusHandler = requestHandler.requestMap[statusCode];
+      expect(statusHandler, isNotNull);
+      final adapterResponse = statusHandler!() as AdapterResponse;
+      final resolvedData = await DefaultTransformer().transformResponse(
+        RequestOptions(path: ''),
+        adapterResponse,
+      );
+      expect(resolvedData, inputData);
+      expect(
+        adapterResponse.headers,
+        {
+          Headers.contentTypeHeader: [
+            Headers.jsonContentType,
+          ],
+        },
+      );
+    });
+
+    test(
+        'sets response data for a status without JSON if content type header is set',
+        () async {
+      const statusCode = HttpStatus.created;
+      const inputData = 'Plain text response';
+      const headers = {
+        Headers.contentTypeHeader: [
+          Headers.textPlainContentType,
+        ],
+      };
+
+      requestHandler.reply(
+        statusCode,
+        inputData,
+        headers: headers,
+      );
+
+      expect(requestHandler.statusCode, statusCode);
+      final statusHandler = requestHandler.requestMap[statusCode];
+      expect(statusHandler, isNotNull);
+      final adapterResponse = statusHandler!() as AdapterResponse;
+      final resolvedData = await DefaultTransformer().transformResponse(
+        RequestOptions(path: ''),
+        adapterResponse,
+      );
+      expect(resolvedData, inputData);
+      expect(adapterResponse.headers, headers);
+    });
+
+    test('sets DioError for a status code', () async {
+      const statusCode = HttpStatus.badRequest;
+      final dioError = DioError(
+        requestOptions: RequestOptions(
+          path: 'path',
+        ),
+        type: DioErrorType.response,
+      );
+
+      requestHandler.throws(
+        statusCode,
+        dioError,
+      );
+
+      expect(requestHandler.statusCode, statusCode);
+      final statusHandler = requestHandler.requestMap[statusCode];
+      expect(statusHandler, isNotNull);
+      final adapterError = statusHandler!() as AdapterError;
+      expect(adapterError.type, dioError.type);
+    });
+  });
+}

--- a/test/http_mock_adapter_test.dart
+++ b/test/http_mock_adapter_test.dart
@@ -1,5 +1,6 @@
 import 'adapters/dio_adapter_mockito_test.dart' as dio_adapter_mockito_test;
 import 'adapters/dio_adapter_test.dart' as dio_adapter_test;
+import 'handlers/request_handler_test.dart' as request_handler_test;
 import 'interceptors/dio_interceptor_test.dart' as dio_interceptor_test;
 import 'matchers/any_test.dart' as any_test;
 import 'matchers/boolean_test.dart' as boolean_test;
@@ -15,6 +16,9 @@ void main() {
   // Adapters.
   dio_adapter_mockito_test.main();
   dio_adapter_test.main();
+
+  // Handlers.
+  request_handler_test.main();
 
   // Interceptors.
   dio_interceptor_test.main();


### PR DESCRIPTION
## Description

- Fix #107 by only calling `jsonEncode` in `RequestHandler` when `Headers.jsonContentType` is set in headers. Otherwise will pass the data provided to the `AdapterResponse`.
- Add unit tests for `RequestHandler` class.
- Add coverage folder to `.gitignore`.

Please let me know if there is anything I should change.

Thank you!