### PR TITLE
Fix missing expectation in map not causing test failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ import 'package:http_mock_adapter/http_mock_adapter.dart';
 
 void main() async {
   final dio = Dio(BaseOptions());
-  final dioAdapter = DioAdapter.configure(dio: dio);
+  final dioAdapter = DioAdapter(dio: dio);
 
   const path = 'https://example.com';
 
   dioAdapter.onGet(
     path,
-    (request) => request.reply(200, {'message': 'Success!'}),
+    (server) => server.reply(200, {'message': 'Success!'}),
   );
 
   final response = await dio.get(path);

--- a/README.md
+++ b/README.md
@@ -20,10 +20,8 @@ import 'package:dio/dio.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
 
 void main() async {
-  final dio = Dio();
-  final dioAdapter = DioAdapter();
-
-  dio.httpClientAdapter = dioAdapter;
+  final dio = Dio(BaseOptions());
+  final dioAdapter = DioAdapter.configure(dio: dio);
 
   const path = 'https://example.com';
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -18,7 +18,7 @@ void main() async {
 
     setUp(() {
       dio = Dio(BaseOptions(baseUrl: baseUrl));
-      dioAdapter = DioAdapter.configure(dio: dio);
+      dioAdapter = DioAdapter(dio: dio);
     });
 
     test('signs up user', () async {
@@ -26,7 +26,7 @@ void main() async {
 
       dioAdapter.onPost(
         route,
-        (request) => request.reply(201, null),
+        (server) => server.reply(201, null),
         data: userCredentials,
       );
 
@@ -58,7 +58,7 @@ void main() async {
       dioAdapter
         ..onPost(
           signInRoute,
-          (request) => request.throws(
+          (server) => server.throws(
             401,
             DioError(
               requestOptions: RequestOptions(
@@ -69,12 +69,12 @@ void main() async {
         )
         ..onPost(
           signInRoute,
-          (request) => request.reply(200, accessToken),
+          (server) => server.reply(200, accessToken),
           data: userCredentials,
         )
         ..onGet(
           accountRoute,
-          (request) => request.reply(200, userInformation),
+          (server) => server.reply(200, userInformation),
           headers: headers,
         );
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -18,9 +18,7 @@ void main() async {
 
     setUp(() {
       dio = Dio(BaseOptions(baseUrl: baseUrl));
-      dioAdapter = DioAdapter();
-
-      dio.httpClientAdapter = dioAdapter;
+      dioAdapter = DioAdapter.configure(dio: dio);
     });
 
     test('signs up user', () async {

--- a/lib/http_mock_adapter.dart
+++ b/lib/http_mock_adapter.dart
@@ -1,6 +1,6 @@
 export 'src/adapters/dio_adapter.dart';
-export 'src/extensions/matches_request.dart';
 export 'src/exceptions.dart' show MockDioError;
+export 'src/extensions/matches_request.dart';
 export 'src/interceptors/dio_interceptor.dart';
 export 'src/matchers/matchers.dart';
 export 'src/request.dart' show Request, RequestMethods;

--- a/lib/src/adapters/dio_adapter.dart
+++ b/lib/src/adapters/dio_adapter.dart
@@ -1,75 +1,23 @@
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
-import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:http_mock_adapter/src/exceptions.dart';
-import 'package:http_mock_adapter/src/handlers/request_handler.dart';
 import 'package:http_mock_adapter/src/mixins/mixins.dart';
-import 'package:http_mock_adapter/src/request.dart';
 import 'package:http_mock_adapter/src/response.dart';
-import 'package:http_mock_adapter/src/types.dart';
 
 /// [HttpClientAdapter] extension with data mocking and recording functionality.
 class DioAdapter extends HttpClientAdapter with Recording, RequestHandling {
   /// State of [DioAdapter] that can be closed to prohibit functionality.
   bool _isClosed = false;
 
-  /// These should be the same [BaseOptions] that are configured for [Dio].
-  final BaseOptions baseOptions;
-
-  DioAdapter({
-    required this.baseOptions,
-  });
-
-  /// Simple helper function to create an adapter
-  /// and configure it correctly with an existing [Dio] instance.
-  factory DioAdapter.configure({required Dio dio}) {
-    final adapter = DioAdapter(baseOptions: dio.options);
-    dio.httpClientAdapter = adapter;
-    return adapter;
-  }
-
-  /// Takes in [route], [request], sets corresponding [RequestHandler],
-  /// adds an instance of [RequestMatcher] in [history].
   @override
-  void onRoute(
-    Pattern route,
-    MockServerCallback requestHandlerCallback, {
-    required Request request,
+  final Dio dio;
+
+  /// Constructs a [DioAdapter] and configures the passed [Dio] instance.
+  DioAdapter({
+    required this.dio,
   }) {
-    final requestData = request.data;
-    final requestMethod =
-        request.method ?? RequestMethods.forName(name: baseOptions.method);
-
-    Map<String, dynamic> requestHeaders = {...request.headers ?? {}};
-
-    if (requestMethod.isAllowedPayloadMethod ||
-        baseOptions.setRequestContentTypeWhenNoPayload) {
-      requestHeaders.putIfAbsent(
-        Headers.contentTypeHeader,
-        () => Headers.jsonContentType,
-      );
-    }
-
-    if (requestMethod.isAllowedPayloadMethod && requestData != null) {
-      requestHeaders.putIfAbsent(
-        Headers.contentLengthHeader,
-        () => Matchers.integer,
-      );
-    }
-
-    request = Request(
-      route: route,
-      method:
-          request.method ?? RequestMethods.forName(name: baseOptions.method),
-      data: requestData,
-      queryParameters: request.queryParameters ?? baseOptions.queryParameters,
-      headers: requestHeaders,
-    );
-
-    final matcher = RequestMatcher(request);
-    requestHandlerCallback(matcher);
-    history.add(matcher);
+    dio.httpClientAdapter = this;
   }
 
   /// [DioAdapter]`s [fetch] configuration intended to work with mock data.
@@ -86,6 +34,7 @@ class DioAdapter extends HttpClientAdapter with Recording, RequestHandling {
       );
     }
 
+    await setDefaultRequestHeaders(dio, requestOptions);
     final response = mockResponse(requestOptions);
 
     // Throws DioError if response type is MockDioError.

--- a/lib/src/adapters/dio_adapter.dart
+++ b/lib/src/adapters/dio_adapter.dart
@@ -39,7 +39,7 @@ class DioAdapter extends HttpClientAdapter with Recording, RequestHandling {
   @override
   void onRoute(
     Pattern route,
-    RequestHandlerCallback requestHandlerCallback, {
+    MockServerCallback requestHandlerCallback, {
     required Request request,
   }) {
     final requestData = request.data ?? data;
@@ -60,18 +60,9 @@ class DioAdapter extends HttpClientAdapter with Recording, RequestHandling {
       headers: requestHeaders,
     );
 
-    final requestHandler = RequestHandler<DioAdapter>(
-      requestSignature: request.signature,
-    );
-
-    requestHandlerCallback(requestHandler);
-
-    history.add(
-      RequestMatcher(
-        request,
-        requestHandler,
-      ),
-    );
+    final matcher = RequestMatcher(request);
+    requestHandlerCallback(matcher);
+    history.add(matcher);
   }
 
   /// [DioAdapter]`s [fetch] configuration intended to work with mock data.

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,8 +1,0 @@
-import 'package:dio/dio.dart';
-import 'package:http_mock_adapter/src/request.dart';
-
-const defaultRequestMethod = RequestMethods.get;
-const defaultQueryParameters = <String, dynamic>{};
-const defaultHeaders = <String, dynamic>{
-  Headers.contentTypeHeader: Headers.jsonContentType,
-};

--- a/lib/src/extensions/extensions.dart
+++ b/lib/src/extensions/extensions.dart
@@ -1,3 +1,2 @@
 export 'package:http_mock_adapter/src/extensions/matches_request.dart';
 export 'package:http_mock_adapter/src/extensions/signature.dart';
-export 'package:http_mock_adapter/src/extensions/to_upper_case_string.dart';

--- a/lib/src/extensions/matches_request.dart
+++ b/lib/src/extensions/matches_request.dart
@@ -1,5 +1,4 @@
 import 'package:dio/dio.dart';
-import 'package:http_mock_adapter/src/extensions/to_upper_case_string.dart';
 import 'package:http_mock_adapter/src/matchers/matchers.dart';
 import 'package:http_mock_adapter/src/request.dart';
 
@@ -26,7 +25,7 @@ extension MatchesRequest on RequestOptions {
     final headersMatched = matches(headers, requestHeaders);
 
     if (!routeMatched ||
-        method != request.method?.toUpperCaseString ||
+        method != request.method?.name ||
         !requestBodyMatched ||
         !queryParametersMatched ||
         !headersMatched) {

--- a/lib/src/extensions/matches_request.dart
+++ b/lib/src/extensions/matches_request.dart
@@ -71,8 +71,8 @@ extension MatchesRequest on RequestOptions {
         return false;
       }
     } else if (actual is Map && expected is Map) {
-      for (final key in actual.keys.toList()) {
-        if (!expected.containsKey(key)) {
+      for (final key in expected.keys.toList()) {
+        if (!actual.containsKey(key)) {
           return false;
         } else if (expected[key] is Matcher) {
           // Check matcher for the configured request.

--- a/lib/src/extensions/matches_request.dart
+++ b/lib/src/extensions/matches_request.dart
@@ -10,29 +10,15 @@ extension MatchesRequest on RequestOptions {
   bool matchesRequest(Request request) {
     final routeMatched = doesRouteMatch(path, request.route);
     final requestBodyMatched = matches(data, request.data);
+    final queryParametersMatched =
+        matches(queryParameters, request.queryParameters ?? {});
+    final headersMatched = matches(headers, request.headers ?? {});
 
-    final queryParametersMatched = matches(
-      queryParameters,
-      request.queryParameters,
-    );
-
-    // Dio adds headers to the request when none are specified.
-    final requestHeaders = request.headers ??
-        {
-          Headers.contentTypeHeader: Headers.jsonContentType,
-        };
-
-    final headersMatched = matches(headers, requestHeaders);
-
-    if (!routeMatched ||
-        method != request.method?.name ||
-        !requestBodyMatched ||
-        !queryParametersMatched ||
-        !headersMatched) {
-      return false;
-    }
-
-    return true;
+    return routeMatched &&
+        method == request.method?.name &&
+        requestBodyMatched &&
+        queryParametersMatched &&
+        headersMatched;
   }
 
   /// Check to see if route matches the mock specification

--- a/lib/src/extensions/to_upper_case_string.dart
+++ b/lib/src/extensions/to_upper_case_string.dart
@@ -1,8 +1,0 @@
-import 'package:http_mock_adapter/src/request.dart';
-
-/// [ToUpperCaseString] extension method grants [RequestMethods] enumeration
-/// the ability to obtain [String] type depictions of enumeration's values.
-extension ToUpperCaseString on RequestMethods {
-  /// Gets the [String] depiction of the current value.
-  String get toUpperCaseString => toString().split('.').last.toUpperCase();
-}

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -33,7 +33,7 @@ class DioInterceptor extends Interceptor with Recording, RequestHandling {
   @override
   void onRoute(
     Pattern route,
-    RequestHandlerCallback requestHandlerCallback, {
+    MockServerCallback requestHandlerCallback, {
     required Request request,
   }) {
     request = Request(
@@ -44,18 +44,9 @@ class DioInterceptor extends Interceptor with Recording, RequestHandling {
       headers: request.headers ?? headers,
     );
 
-    final requestHandler = RequestHandler<DioInterceptor>(
-      requestSignature: request.signature,
-    );
-
-    requestHandlerCallback(requestHandler);
-
-    history.add(
-      RequestMatcher(
-        request,
-        requestHandler,
-      ),
-    );
+    final matcher = RequestMatcher(request);
+    requestHandlerCallback(matcher);
+    history.add(matcher);
   }
 
   /// Dio [Interceptor]`s [onRequest] configuration intended to catch and return

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -1,74 +1,24 @@
 import 'package:dio/dio.dart';
-import 'package:http_mock_adapter/http_mock_adapter.dart';
-import 'package:http_mock_adapter/src/handlers/request_handler.dart';
 import 'package:http_mock_adapter/src/mixins/mixins.dart';
-import 'package:http_mock_adapter/src/request.dart';
 import 'package:http_mock_adapter/src/response.dart';
-import 'package:http_mock_adapter/src/types.dart';
 
 /// [DioInterceptor] is a class for mocking [Dio] requests with [Interceptor].
 class DioInterceptor extends Interceptor with Recording, RequestHandling {
-  /// These should be the same [BaseOptions] that are configured for [Dio].
-  final BaseOptions baseOptions;
-
-  DioInterceptor({
-    required this.baseOptions,
-  });
-
-  /// Simple helper function to create an adapter
-  /// and configure it correctly with an existing [Dio] instance.
-  factory DioInterceptor.configure({required Dio dio}) {
-    final interceptor = DioInterceptor(baseOptions: dio.options);
-    dio.interceptors.add(interceptor);
-    return interceptor;
-  }
-
-  /// Takes in route, request, sets corresponding [RequestHandler],
-  /// adds an instance of [RequestMatcher] in [history].
   @override
-  void onRoute(
-    Pattern route,
-    MockServerCallback requestHandlerCallback, {
-    required Request request,
+  final Dio dio;
+
+  /// Constructs a [DioInterceptor] and configures the passed [Dio] instance.
+  DioInterceptor({
+    required this.dio,
   }) {
-    final requestData = request.data;
-    final requestMethod =
-        request.method ?? RequestMethods.forName(name: baseOptions.method);
-
-    Map<String, dynamic> requestHeaders = {...request.headers ?? {}};
-
-    if (requestMethod.isAllowedPayloadMethod ||
-        baseOptions.setRequestContentTypeWhenNoPayload) {
-      requestHeaders.putIfAbsent(
-        Headers.contentTypeHeader,
-        () => Headers.jsonContentType,
-      );
-    }
-
-    if (requestMethod.isAllowedPayloadMethod && requestData != null) {
-      requestHeaders.putIfAbsent(
-        Headers.contentLengthHeader,
-        () => Matchers.integer,
-      );
-    }
-
-    request = Request(
-      route: route,
-      method: requestMethod,
-      data: requestData,
-      queryParameters: request.queryParameters ?? baseOptions.queryParameters,
-      headers: requestHeaders,
-    );
-
-    final matcher = RequestMatcher(request);
-    requestHandlerCallback(matcher);
-    history.add(matcher);
+    dio.interceptors.add(this);
   }
 
   /// Dio [Interceptor]`s [onRequest] configuration intended to catch and return
   /// mocked request and data respectively.
   @override
   void onRequest(requestOptions, requestInterceptorHandler) async {
+    await setDefaultRequestHeaders(dio, requestOptions);
     final response = mockResponse(requestOptions);
 
     // Reject the response if type is MockDioError.
@@ -82,7 +32,7 @@ class DioInterceptor extends Interceptor with Recording, RequestHandling {
 
     requestInterceptorHandler.resolve(
       Response(
-        data: await DefaultTransformer().transformResponse(
+        data: await dio.transformer.transformResponse(
           requestOptions,
           responseBody,
         ),

--- a/lib/src/mixins/recording.dart
+++ b/lib/src/mixins/recording.dart
@@ -22,11 +22,6 @@ mixin Recording {
           if (requestOptions.signature == requestMatcher.request.signature ||
               requestOptions.matchesRequest(requestMatcher.request)) {
             _invocationIndex = _requestMatchers.indexOf(requestMatcher);
-
-            final requestHandler = requestMatcher.requestHandler;
-
-            requestMatcher.mockResponse =
-                requestHandler.mockResponses[requestHandler.requestSignature];
           }
         }
 
@@ -37,7 +32,7 @@ mixin Recording {
           );
         }
 
-        return requestMatcher.mockResponse!();
+        return requestMatcher.mockResponse();
       };
 
   /// Keeps track of request and response history.

--- a/lib/src/mixins/request_handling.dart
+++ b/lib/src/mixins/request_handling.dart
@@ -50,7 +50,7 @@ mixin RequestHandling on Recording {
     final requestMethod =
         request.method ?? RequestMethods.forName(name: dio.options.method);
 
-    Map<String, dynamic> requestHeaders = {...request.headers ?? {}};
+    Map<String, dynamic> requestHeaders = {...?request.headers};
 
     if (requestMethod.isAllowedPayloadMethod ||
         dio.options.setRequestContentTypeWhenNoPayload) {

--- a/lib/src/mixins/request_handling.dart
+++ b/lib/src/mixins/request_handling.dart
@@ -9,7 +9,7 @@ import 'package:http_mock_adapter/src/types.dart';
 mixin RequestHandling {
   void onRoute(
     Pattern route,
-    RequestHandlerCallback requestHandlerCallback, {
+    MockServerCallback requestHandlerCallback, {
     required Request request,
   });
 
@@ -17,7 +17,7 @@ mixin RequestHandling {
   /// and sets corresponding [RequestHandler].
   void onGet(
     Pattern route,
-    RequestHandlerCallback requestHandlerCallback, {
+    MockServerCallback requestHandlerCallback, {
     dynamic data,
     Map<String, dynamic>? queryParameters,
     Map<String, dynamic>? headers,
@@ -38,7 +38,7 @@ mixin RequestHandling {
   /// and sets corresponding [RequestHandler].
   void onHead(
     Pattern route,
-    RequestHandlerCallback requestHandlerCallback, {
+    MockServerCallback requestHandlerCallback, {
     dynamic data,
     Map<String, dynamic>? queryParameters,
     Map<String, dynamic>? headers,
@@ -59,7 +59,7 @@ mixin RequestHandling {
   /// and sets corresponding [RequestHandler].
   void onPost(
     Pattern route,
-    RequestHandlerCallback requestHandlerCallback, {
+    MockServerCallback requestHandlerCallback, {
     dynamic data,
     Map<String, dynamic>? queryParameters,
     Map<String, dynamic>? headers,
@@ -80,7 +80,7 @@ mixin RequestHandling {
   /// and sets corresponding [RequestHandler].
   void onPut(
     Pattern route,
-    RequestHandlerCallback requestHandlerCallback, {
+    MockServerCallback requestHandlerCallback, {
     dynamic data,
     Map<String, dynamic>? queryParameters,
     Map<String, dynamic>? headers,
@@ -101,7 +101,7 @@ mixin RequestHandling {
   /// and sets corresponding [RequestHandler].
   void onDelete(
     Pattern route,
-    RequestHandlerCallback requestHandlerCallback, {
+    MockServerCallback requestHandlerCallback, {
     dynamic data,
     Map<String, dynamic>? queryParameters,
     Map<String, dynamic>? headers,
@@ -122,7 +122,7 @@ mixin RequestHandling {
   /// and sets corresponding [RequestHandler].
   void onPatch(
     Pattern route,
-    RequestHandlerCallback requestHandlerCallback, {
+    MockServerCallback requestHandlerCallback, {
     dynamic data,
     Map<String, dynamic>? queryParameters,
     Map<String, dynamic>? headers,

--- a/lib/src/mixins/request_handling.dart
+++ b/lib/src/mixins/request_handling.dart
@@ -35,10 +35,6 @@ mixin RequestHandling on Recording {
           bytes = utf8.encode(_data);
         }
         options.headers[Headers.contentLengthHeader] = bytes.length.toString();
-        options.headers.putIfAbsent(
-          Headers.contentTypeHeader,
-          () => Headers.jsonContentType,
-        );
       }
     }
   }

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -38,22 +38,12 @@ class Request {
       );
 }
 
-/// Matcher of [Request] and [mockResponse] based on route and [RequestHandler].
-class RequestMatcher {
+/// Matches a [Request] to a [MockResponse].
+class RequestMatcher extends RequestHandler {
   /// This is a request sent by the the client.
   final Request request;
 
-  /// This is a request handler that processes requests.
-  final RequestHandler requestHandler;
-
-  /// This is an artificial response body to the request.
-  MockResponse Function()? mockResponse;
-
-  RequestMatcher(
-    this.request,
-    this.requestHandler, {
-    this.mockResponse,
-  });
+  RequestMatcher(this.request);
 }
 
 /// HTTP methods.

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -1,4 +1,4 @@
-import 'package:http_mock_adapter/src/extensions/extensions.dart';
+import 'package:dio/dio.dart';
 import 'package:http_mock_adapter/src/handlers/request_handler.dart';
 import 'package:http_mock_adapter/src/response.dart';
 import 'package:http_mock_adapter/src/utils.dart';
@@ -30,7 +30,7 @@ class Request {
 
   /// [signature] is the [String] representation of the [Request]'s body.
   String get signature => buildRequestSignature(
-        method?.toUpperCaseString,
+        method?.name,
         route,
         data,
         queryParameters,
@@ -47,26 +47,43 @@ class RequestMatcher extends RequestHandler {
 }
 
 /// HTTP methods.
-enum RequestMethods {
+class RequestMethods {
   /// The [get] method requests a representation of the specified resource.
   /// Requests using [get] should only retrieve data.
-  get,
+  static const RequestMethods get = RequestMethods._('GET');
 
   /// The [head] method asks for a response identical to that of a [get] request,
   /// but without the response body.
-  head,
+  static const RequestMethods head = RequestMethods._('HEAD');
 
   /// The [post] method is used to submit an entity to the specified resource,
   /// often causing a change in state or side effects on the server.
-  post,
+  static const RequestMethods post = RequestMethods._('POST');
 
   /// The [put] method replaces all current representations of the
   /// target resource with the request payload.
-  put,
+  static const RequestMethods put = RequestMethods._('PUT');
 
   /// The [delete] method deletes the specified resource.
-  delete,
+  static const RequestMethods delete = RequestMethods._('DELETE');
 
   /// The [patch] method is used to apply partial modifications to a resource.
-  patch,
+  static const RequestMethods patch = RequestMethods._('PATCH');
+
+  /// Taken from [BaseOptions]. The default methods that are considered
+  /// to have a payload. Only for these methods a default content-type header is
+  /// added, if no specified.
+  static const allowedPayloadMethods = [post, put, patch, delete];
+
+  static const _all = [get, head, post, put, patch, delete];
+
+  final String name;
+
+  bool get isAllowedPayloadMethod => allowedPayloadMethods.contains(this);
+
+  factory RequestMethods.forName({required String name}) {
+    return _all.firstWhere((m) => m.name == name);
+  }
+
+  const RequestMethods._(this.name);
 }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -5,7 +5,7 @@ import 'package:http_mock_adapter/src/request.dart';
 import 'package:http_mock_adapter/src/response.dart';
 
 /// Type for request handler callbacks in the [RequestHandling].
-typedef RequestHandlerCallback = void Function(RequestHandler request);
+typedef MockServerCallback = void Function(MockServer server);
 
 /// Type for [Recording]'s [ResponseBody], which takes [RequestOptions] as a parameter
 /// and compares its signature to saved [Request]'s signature and chooses right response.

--- a/test/adapters/dio_adapter_test.dart
+++ b/test/adapters/dio_adapter_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:http_mock_adapter/src/exceptions.dart';
@@ -88,8 +90,10 @@ void main() {
       expect(response.data, {});
     });
 
-    test('sets default headers without request encoder', () async {
-      dio = Dio(BaseOptions(requestEncoder: null));
+    test('sets default headers with custom request encoder', () async {
+      dio = Dio(BaseOptions(
+        requestEncoder: (request, options) => utf8.encode(request),
+      ));
       dioAdapter = DioAdapter(dio: dio);
 
       dioAdapter.onPut(

--- a/test/adapters/dio_adapter_test.dart
+++ b/test/adapters/dio_adapter_test.dart
@@ -19,7 +19,7 @@ void main() {
 
   setUp(() {
     dio = Dio();
-    dioAdapter = DioAdapter.configure(dio: dio);
+    dioAdapter = DioAdapter(dio: dio);
   });
 
   group('DioAdapter', () {
@@ -33,7 +33,7 @@ void main() {
     }
 
     test('uses default values from constructor', () async {
-      dioAdapter.onGet('/example', (request) => request.reply(200, {}));
+      dioAdapter.onGet('/example', (server) => server.reply(200, {}));
 
       response = await dio.get('/example');
 
@@ -46,11 +46,11 @@ void main() {
           Headers.contentLengthHeader: Matchers.integer,
         },
       ));
-      dioAdapter = DioAdapter.configure(dio: dio);
+      dioAdapter = DioAdapter(dio: dio);
 
       dioAdapter.onRoute(
         '/example',
-        (request) => request.reply(200, {}),
+        (server) => server.reply(200, {}),
         request: const Request(
           data: {},
         ),
@@ -59,11 +59,6 @@ void main() {
       response = await dio.post(
         '/example',
         data: {},
-        options: Options(
-          headers: {
-            Headers.contentTypeHeader: Headers.jsonContentType,
-          },
-        ),
       );
 
       expect(response.data, {});
@@ -83,7 +78,7 @@ void main() {
 
         dioAdapter.onGet(
           path,
-          (request) => request.throws(500, dioError),
+          (server) => server.throws(500, dioError),
         );
 
         expect(() async => await dio.get(path), throwsA(isA<MockDioError>()));
@@ -104,7 +99,7 @@ void main() {
       test('mocks requests via onRoute() as intended', () async {
         dioAdapter.onRoute(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
           request: const Request(),
         );
 
@@ -114,7 +109,7 @@ void main() {
       test('mocks requests via onGet() as intended', () async {
         dioAdapter.onGet(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         );
 
         await testDioAdapter(() => dio.get(path), data);
@@ -123,7 +118,7 @@ void main() {
       test('mocks requests via onHead() as intended', () async {
         dioAdapter.onHead(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         );
 
         await testDioAdapter(() => dio.head(path), data);
@@ -132,7 +127,7 @@ void main() {
       test('mocks requests via onPost() as intended', () async {
         dioAdapter.onPost(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         );
 
         await testDioAdapter(() => dio.post(path), data);
@@ -141,7 +136,7 @@ void main() {
       test('mocks requests via onPut() as intended', () async {
         dioAdapter.onPut(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         );
 
         await testDioAdapter(() => dio.put(path), data);
@@ -150,7 +145,7 @@ void main() {
       test('mocks requests via onDelete() as intended', () async {
         dioAdapter.onDelete(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         );
 
         await testDioAdapter(() => dio.delete(path), data);
@@ -159,7 +154,7 @@ void main() {
       test('mocks requests via onPatch() as intended', () async {
         dioAdapter.onPatch(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         );
 
         await testDioAdapter(() => dio.patch(path), data);
@@ -173,7 +168,7 @@ void main() {
 
         dioAdapter.onGet(
           '/search',
-          (request) => request.reply(200, books),
+          (server) => server.reply(200, books),
           queryParameters: {'query': 'book'},
         );
 
@@ -188,7 +183,7 @@ void main() {
       test('mocks multiple requests sequentially as intended', () async {
         dioAdapter.onPost(
           '/route',
-          (request) => request.reply(201, {
+          (server) => server.reply(201, {
             'message': 'Post!',
           }),
           data: {'post': '201'},
@@ -200,7 +195,7 @@ void main() {
 
         dioAdapter.onPatch(
           '/routes',
-          (request) => request.reply(207, {
+          (server) => server.reply(207, {
             'message': 'Patch!',
           }),
           data: {'patch': '207'},
@@ -211,7 +206,7 @@ void main() {
 
         dioAdapter.onGet(
           '/api',
-          (request) => request.reply(200, {
+          (server) => server.reply(200, {
             'message': 'Get!',
           }),
         );
@@ -225,19 +220,19 @@ void main() {
         dioAdapter
           ..onGet(
             '/first-route',
-            (request) => request.reply(200, {'message': 'First!'}),
+            (server) => server.reply(200, {'message': 'First!'}),
           )
           ..onGet(
             '/second-route',
-            (request) => request.reply(200, {'message': 'Second!'}),
+            (server) => server.reply(200, {'message': 'Second!'}),
           )
           ..onPost(
             '/second-route',
-            (request) => request.reply(200, {'message': 'Second again!'}),
+            (server) => server.reply(200, {'message': 'Second again!'}),
           )
           ..onGet(
             '/third-route',
-            (request) => request.reply(200, {'message': 'Third!'}),
+            (server) => server.reply(200, {'message': 'Third!'}),
           );
 
         response = await dio.get('/second-route');
@@ -257,11 +252,11 @@ void main() {
         dioAdapter
           ..onGet(
             '/route',
-            (request) => request.reply(201, {'message': 'Unbreakable...'}),
+            (server) => server.reply(201, {'message': 'Unbreakable...'}),
           )
           ..onGet(
             '/api',
-            (request) => request.reply(200, {'message': 'Chain!'}),
+            (server) => server.reply(200, {'message': 'Chain!'}),
           );
 
         response = await dio.get('/route');
@@ -274,7 +269,7 @@ void main() {
       test('mocks route pattern', () async {
         dioAdapter.onGet(
           RegExp(r'/test-route/[0-9]{6}'),
-          (request) => request.reply(200, {'message': 'Test!'}),
+          (server) => server.reply(200, {'message': 'Test!'}),
         );
 
         response = await dio.get('/test-route/123456');
@@ -284,7 +279,7 @@ void main() {
       test('returns a new response every time for the same request', () async {
         dioAdapter.onGet(
           '/route',
-          (request) => request.reply(200, {'message': 'Success'}),
+          (server) => server.reply(200, {'message': 'Success'}),
         );
 
         response = await dio.get('/route');
@@ -300,7 +295,7 @@ void main() {
 
       dioAdapter.onGet(
         '/route',
-        (request) => request.reply(200, {'message': 'Success'}),
+        (server) => server.reply(200, {'message': 'Success'}),
       );
 
       expect(

--- a/test/adapters/dio_adapter_test.dart
+++ b/test/adapters/dio_adapter_test.dart
@@ -18,8 +18,8 @@ void main() {
   const statusCode = 200;
 
   setUp(() {
-    dioAdapter = DioAdapter();
-    dio = Dio()..httpClientAdapter = dioAdapter;
+    dio = Dio();
+    dioAdapter = DioAdapter.configure(dio: dio);
   });
 
   group('DioAdapter', () {
@@ -39,18 +39,21 @@ void main() {
 
       expect(response.data, {});
 
-      dioAdapter
-        ..method = RequestMethods.post
-        ..data = {}
-        ..headers = {
+      dio = Dio(BaseOptions(
+        method: RequestMethods.post.name,
+        headers: {
           Headers.contentTypeHeader: Headers.jsonContentType,
           Headers.contentLengthHeader: Matchers.integer,
-        };
+        },
+      ));
+      dioAdapter = DioAdapter.configure(dio: dio);
 
       dioAdapter.onRoute(
         '/example',
         (request) => request.reply(200, {}),
-        request: const Request(),
+        request: const Request(
+          data: {},
+        ),
       );
 
       response = await dio.post(

--- a/test/adapters/dio_adapter_test.dart
+++ b/test/adapters/dio_adapter_test.dart
@@ -64,6 +64,56 @@ void main() {
       expect(response.data, {});
     });
 
+    test('sets default headers for form-data', () async {
+      dioAdapter.onPut(
+        '/example',
+        (server) => server.reply(200, {}),
+        data: Matchers.formData(FormData.fromMap({
+          'foo': 'bar',
+        })),
+        headers: <String, Object?>{
+          Headers.contentTypeHeader:
+              Matchers.pattern('multipart/form-data; boundary=.*'),
+          Headers.contentLengthHeader: Matchers.integer,
+        },
+      );
+
+      response = await dio.put(
+        '/example',
+        data: FormData.fromMap({
+          'foo': 'bar',
+        }),
+      );
+
+      expect(response.data, {});
+    });
+
+    test('sets default headers without request encoder', () async {
+      dio = Dio(BaseOptions(requestEncoder: null));
+      dioAdapter = DioAdapter(dio: dio);
+
+      dioAdapter.onPut(
+        '/example',
+        (server) => server.reply(200, {}),
+        data: {
+          'foo': 'bar',
+        },
+        headers: <String, Object?>{
+          Headers.contentTypeHeader: Headers.jsonContentType,
+          Headers.contentLengthHeader: Matchers.integer,
+        },
+      );
+
+      response = await dio.put(
+        '/example',
+        data: {
+          'foo': 'bar',
+        },
+      );
+
+      expect(response.data, {});
+    });
+
     group('RequestRouted', () {
       test('Test that throws raises custom exception', () async {
         final dioError = DioError(

--- a/test/extensions/matches_request_test.dart
+++ b/test/extensions/matches_request_test.dart
@@ -228,6 +228,23 @@ void main() {
 
           expect({'message': 'Test!'}, response.data);
         });
+
+        test('fails on unsatisfied header expectation', () async {
+          dioAdapter.onGet(
+            path,
+            (request) => request.reply(statusCode, data),
+            headers: {
+              Headers.contentLengthHeader: Matchers.integer,
+            },
+          );
+
+          expect(
+              () => dio.get(path),
+              throwsA(predicate((e) =>
+                  e is DioError &&
+                  e.type == DioErrorType.other &&
+                  e.error is AssertionError)));
+        });
       });
     });
   });

--- a/test/extensions/matches_request_test.dart
+++ b/test/extensions/matches_request_test.dart
@@ -164,13 +164,13 @@ void main() {
 
         setUpAll(() {
           dio = Dio();
-          dioAdapter = DioAdapter.configure(dio: dio);
+          dioAdapter = DioAdapter(dio: dio);
         });
 
         test('mocks requests via onPost() with matchers as intended', () async {
           dioAdapter.onPost(
             '/post-any-data',
-            (request) => request.reply(statusCode, data),
+            (server) => server.reply(statusCode, data),
             data: {
               'any': Matchers.any,
               'boolean': Matchers.boolean,
@@ -216,7 +216,7 @@ void main() {
 
           dioAdapter.onPost(
             path,
-            (request) => request.reply(statusCode, data),
+            (server) => server.reply(statusCode, data),
             data: {'date': Matchers.pattern(pattern)},
             headers: {
               Headers.contentTypeHeader: Matchers.pattern('application'),
@@ -232,7 +232,7 @@ void main() {
         test('fails on unsatisfied header expectation', () async {
           dioAdapter.onGet(
             path,
-            (request) => request.reply(statusCode, data),
+            (server) => server.reply(statusCode, data),
             headers: {
               Headers.contentLengthHeader: Matchers.integer,
             },

--- a/test/extensions/matches_request_test.dart
+++ b/test/extensions/matches_request_test.dart
@@ -160,21 +160,14 @@ void main() {
 
         Response<dynamic> response;
         const statusCode = 200;
-        DioAdapter dioAdapter;
+        late DioAdapter dioAdapter;
 
         setUpAll(() {
           dio = Dio();
-
-          dioAdapter = DioAdapter();
-
-          dio.httpClientAdapter = dioAdapter;
+          dioAdapter = DioAdapter.configure(dio: dio);
         });
 
         test('mocks requests via onPost() with matchers as intended', () async {
-          dioAdapter = DioAdapter();
-
-          dio.httpClientAdapter = dioAdapter;
-
           dioAdapter.onPost(
             '/post-any-data',
             (request) => request.reply(statusCode, data),
@@ -219,10 +212,6 @@ void main() {
         });
 
         test('mocks date formatted POST request as intended', () async {
-          dioAdapter = DioAdapter();
-
-          dio.httpClientAdapter = dioAdapter;
-
           const pattern = r'(0?[1-9]|[12][0-9]|3[01])\-(0?[1-9]|1[012])\-\d{4}';
 
           dioAdapter.onPost(

--- a/test/handlers/request_handler_test.dart
+++ b/test/handlers/request_handler_test.dart
@@ -10,10 +10,8 @@ void main() {
   group('RequestHandler', () {
     late RequestHandler requestHandler;
 
-    const requestSignature = 'test';
-
     setUp(() {
-      requestHandler = RequestHandler(requestSignature: requestSignature);
+      requestHandler = RequestHandler();
     });
 
     test('sets response data for a status with JSON by default', () async {
@@ -25,13 +23,11 @@ void main() {
         inputData,
       );
 
-      expect(requestHandler.requestSignature, requestSignature);
-
-      final statusHandler = requestHandler.mockResponses[requestSignature];
+      final statusHandler = requestHandler.mockResponse;
 
       expect(statusHandler, isNotNull);
 
-      final mockResponseBody = statusHandler!() as MockResponseBody;
+      final mockResponseBody = statusHandler() as MockResponseBody;
 
       final resolvedData = await DefaultTransformer().transformResponse(
         RequestOptions(path: ''),
@@ -66,13 +62,11 @@ void main() {
         headers: headers,
       );
 
-      expect(requestHandler.requestSignature, requestSignature);
-
-      final statusHandler = requestHandler.mockResponses[requestSignature];
+      final statusHandler = requestHandler.mockResponse;
 
       expect(statusHandler, isNotNull);
 
-      final mockResponseBody = statusHandler!() as MockResponseBody;
+      final mockResponseBody = statusHandler() as MockResponseBody;
 
       final resolvedData = await DefaultTransformer().transformResponse(
         RequestOptions(path: ''),
@@ -97,13 +91,11 @@ void main() {
         dioError,
       );
 
-      expect(requestHandler.requestSignature, requestSignature);
-
-      final statusHandler = requestHandler.mockResponses[requestSignature];
+      final statusHandler = requestHandler.mockResponse;
 
       expect(statusHandler, isNotNull);
 
-      final mockDioError = statusHandler!() as MockDioError;
+      final mockDioError = statusHandler() as MockDioError;
 
       expect(mockDioError.type, dioError.type);
     });

--- a/test/interceptors/dio_interceptor_test.dart
+++ b/test/interceptors/dio_interceptor_test.dart
@@ -16,10 +16,7 @@ void main() {
 
     setUpAll(() {
       dio = Dio();
-
-      dioInterceptor = DioInterceptor();
-
-      dio.interceptors.add(dioInterceptor);
+      dioInterceptor = DioInterceptor.configure(dio: dio);
     });
 
     Future<void> _testDioInterceptor<T>(
@@ -135,10 +132,6 @@ void main() {
     });
 
     test('mocks multiple requests sequentially by method chaining', () async {
-      final dio = Dio();
-
-      final dioInterceptor = DioInterceptor();
-
       dioInterceptor
         ..onGet(
           path,

--- a/test/interceptors/dio_interceptor_test.dart
+++ b/test/interceptors/dio_interceptor_test.dart
@@ -16,7 +16,7 @@ void main() {
 
     setUpAll(() {
       dio = Dio();
-      dioInterceptor = DioInterceptor.configure(dio: dio);
+      dioInterceptor = DioInterceptor(dio: dio);
     });
 
     Future<void> _testDioInterceptor<T>(
@@ -37,7 +37,7 @@ void main() {
         // on onGet for the specific path.
         dioInterceptor.onGet(
           path,
-          (request) => request.throws(
+          (server) => server.throws(
             500,
             MockDioError(
               type: type,
@@ -69,7 +69,7 @@ void main() {
       test('mocks requests via onRoute() as intended', () async {
         dioInterceptor.onRoute(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
           request: const Request(),
         );
 
@@ -79,7 +79,7 @@ void main() {
       test('mocks requests via onGet() as intended', () async {
         dioInterceptor.onGet(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         );
 
         await _testDioInterceptor(() => dio.get(path), data);
@@ -88,7 +88,7 @@ void main() {
       test('mocks requests via onHead() as intended', () async {
         dioInterceptor.onHead(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         );
 
         await _testDioInterceptor(() => dio.head(path), data);
@@ -97,7 +97,7 @@ void main() {
       test('mocks requests via onPost() as intended', () async {
         dioInterceptor.onPost(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         );
 
         await _testDioInterceptor(() => dio.post(path), data);
@@ -106,7 +106,7 @@ void main() {
       test('mocks requests via onPut() as intended', () async {
         dioInterceptor.onPut(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         );
 
         await _testDioInterceptor(() => dio.put(path), data);
@@ -115,7 +115,7 @@ void main() {
       test('mocks requests via onDelete() as intended', () async {
         dioInterceptor.onDelete(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         );
 
         await _testDioInterceptor(() => dio.delete(path), data);
@@ -124,7 +124,7 @@ void main() {
       test('mocks requests via onPatch() as intended', () async {
         dioInterceptor.onPatch(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         );
 
         await _testDioInterceptor(() => dio.patch(path), data);
@@ -132,18 +132,22 @@ void main() {
     });
 
     test('mocks multiple requests sequentially by method chaining', () async {
+      const sendData = 'foo';
+
       dioInterceptor
         ..onGet(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
         )
         ..onPost(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
+          data: sendData,
         )
         ..onPatch(
           path,
-          (request) => request.reply(statusCode, data),
+          (server) => server.reply(statusCode, data),
+          data: sendData,
         );
 
       dio.interceptors.add(dioInterceptor);
@@ -151,10 +155,10 @@ void main() {
       response = await dio.get(path);
       expect(response.data, data);
 
-      response = await dio.post(path);
+      response = await dio.post(path, data: sendData);
       expect(response.data, data);
 
-      response = await dio.patch(path);
+      response = await dio.patch(path, data: sendData);
       expect(response.data, data);
     });
   });

--- a/test/mixins/recording_test.dart
+++ b/test/mixins/recording_test.dart
@@ -11,9 +11,8 @@ void main() {
   const path = 'https://example.com';
 
   setUpAll(() {
-    dioAdapter = DioAdapter();
-
-    dio = Dio()..httpClientAdapter = dioAdapter;
+    dio = Dio();
+    dioAdapter = DioAdapter.configure(dio: dio);
   });
 
   group('History', () {

--- a/test/mixins/recording_test.dart
+++ b/test/mixins/recording_test.dart
@@ -12,7 +12,7 @@ void main() {
 
   setUpAll(() {
     dio = Dio();
-    dioAdapter = DioAdapter.configure(dio: dio);
+    dioAdapter = DioAdapter(dio: dio);
   });
 
   group('History', () {
@@ -27,7 +27,7 @@ void main() {
 
         dioAdapter.onGet(
           path,
-          (request) => request.reply(200, data),
+          (server) => server.reply(200, data),
         );
 
         response = await dio.get(path);


### PR DESCRIPTION
## Description

Fixes #117 and now causes unmatched expectations in header/query-params (everything that is matched via a map) to cause test failures. Previously they were just ignored.


Additionally this change gives the adapter/interceptor access to the `BaseOptions` in order to access default values which allows easy reuse of existing `Dio` instances and their configuration.

Also removed a lot of unused code in request matchers/handlers.