### PR TITLE
Automatically wrap FormData in a fitting matcher & remove header matcher

### DIFF
--- a/lib/src/mixins/request_handling.dart
+++ b/lib/src/mixins/request_handling.dart
@@ -46,37 +46,22 @@ mixin RequestHandling on Recording {
     MockServerCallback requestHandlerCallback, {
     required Request request,
   }) {
-    final requestData = request.data;
-    final requestMethod =
-        request.method ?? RequestMethods.forName(name: dio.options.method);
+    var requestData = request.data;
 
-    Map<String, dynamic> requestHeaders = {...?request.headers};
-
-    if (requestMethod.isAllowedPayloadMethod ||
-        dio.options.setRequestContentTypeWhenNoPayload) {
-      requestHeaders.putIfAbsent(
-        Headers.contentTypeHeader,
-        () => Headers.jsonContentType,
-      );
+    // Automatically add form data matcher if it is not provided
+    if (requestData is FormData) {
+      requestData = Matchers.formData(requestData);
     }
 
-    if (requestMethod.isAllowedPayloadMethod && requestData != null) {
-      requestHeaders.putIfAbsent(
-        Headers.contentLengthHeader,
-        () => Matchers.integer,
-      );
-    }
-
-    request = Request(
+    final matcher = RequestMatcher(Request(
       route: route,
       method:
           request.method ?? RequestMethods.forName(name: dio.options.method),
       data: requestData,
       queryParameters: request.queryParameters ?? dio.options.queryParameters,
-      headers: requestHeaders,
-    );
+      headers: {...?request.headers},
+    ));
 
-    final matcher = RequestMatcher(request);
     requestHandlerCallback(matcher);
     history.add(matcher);
   }

--- a/test/adapters/dio_adapter_test.dart
+++ b/test/adapters/dio_adapter_test.dart
@@ -70,9 +70,9 @@ void main() {
       dioAdapter.onPut(
         '/example',
         (server) => server.reply(200, {}),
-        data: Matchers.formData(FormData.fromMap({
+        data: FormData.fromMap({
           'foo': 'bar',
-        })),
+        }),
         headers: <String, Object?>{
           Headers.contentTypeHeader:
               Matchers.pattern('multipart/form-data; boundary=.*'),


### PR DESCRIPTION
## Description

Follow up to #118 
Improves developer experience around #111 

* don't automatically add matchers for headers, a test should only contain the expectations set by the user, not any magical expectations by the library
* this was previously needed because the matching code would have failed
* automatically wrap `data: FormData` in a `data: Matchers.formData()` if is is provided - in contrast to the removed header matchers, the user actually added a `data: ` expectation, but not with the correct type, we just help out here

