### PR TITLE
new feature:RequestHandler.reply's parameter data can be a function

### DIFF
--- a/lib/src/extensions/matches_request.dart
+++ b/lib/src/extensions/matches_request.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:http_mock_adapter/src/matchers/matchers.dart';
 import 'package:http_mock_adapter/src/request.dart';
+import 'package:http_mock_adapter/src/types.dart';
 
 /// [MatchesRequest] enhances the [RequestOptions] by allowing different types
 /// of matchers to validate the data and headers of the request.
@@ -50,6 +51,10 @@ extension MatchesRequest on RequestOptions {
       return true;
     }
 
+    /// if data is MockDataCallback do not need to match;
+    if (expected is MockDataCallback) {
+      return true;
+    }
     if (expected is Matcher) {
       /// Check the match here to bypass the fallthrough strict equality check
       /// at the end.

--- a/lib/src/mixins/recording.dart
+++ b/lib/src/mixins/recording.dart
@@ -32,7 +32,7 @@ mixin Recording {
           );
         }
 
-        return requestMatcher.mockResponse();
+        return requestMatcher.mockResponse(requestOptions);
       };
 
   /// Keeps track of request and response history.

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -12,3 +12,7 @@ typedef MockServerCallback = void Function(MockServer server);
 typedef MockResponseBodyCallback = MockResponse Function(
   RequestOptions options,
 );
+/// Type for expect data as function
+typedef MockDataCallback = dynamic Function(
+  RequestOptions options,
+);

--- a/test/extensions/matches_request_test.dart
+++ b/test/extensions/matches_request_test.dart
@@ -36,6 +36,15 @@ void main() {
         );
       });
 
+      test('data is MockDataCallback', () {
+        const actual = {
+          'a': 'a',
+          'b': 'b',
+        };
+
+        expect(options.matches(actual, (option)=>{}), true);
+      });
+
       group('map', () {
         test('exactly', () {
           const actual = {

--- a/test/handlers/request_handler_test.dart
+++ b/test/handlers/request_handler_test.dart
@@ -27,7 +27,8 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockResponseBody = statusHandler() as MockResponseBody;
+      final mockResponseBody =
+          statusHandler(RequestOptions(path: '')) as MockResponseBody;
 
       final resolvedData = await DefaultTransformer().transformResponse(
         RequestOptions(path: ''),
@@ -43,6 +44,34 @@ void main() {
           ],
         },
       );
+    });
+
+    test('sets response data MockDataCallback ', () async {
+      const statusCode = HttpStatus.ok;
+      var data = {'data': 'OK'};
+      dynamic Function(RequestOptions options) inputData;
+      inputData = (options) {
+        return data;
+      };
+
+      requestHandler.reply(
+        statusCode,
+        inputData,
+      );
+
+      final statusHandler = requestHandler.mockResponse;
+
+      expect(statusHandler, isNotNull);
+
+      final mockResponseBody =
+          statusHandler(RequestOptions(path: '')) as MockResponseBody;
+
+      final resolvedData = await DefaultTransformer().transformResponse(
+        RequestOptions(path: ''),
+        mockResponseBody,
+      );
+
+      expect(resolvedData, data);
     });
 
     test(
@@ -66,7 +95,8 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockResponseBody = statusHandler() as MockResponseBody;
+      final mockResponseBody =
+          statusHandler(RequestOptions(path: '')) as MockResponseBody;
 
       final resolvedData = await DefaultTransformer().transformResponse(
         RequestOptions(path: ''),
@@ -95,7 +125,8 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockDioError = statusHandler() as MockDioError;
+      final mockDioError =
+          statusHandler(RequestOptions(path: '')) as MockDioError;
 
       expect(mockDioError.type, dioError.type);
     });

--- a/test/mixins/recording_test.dart
+++ b/test/mixins/recording_test.dart
@@ -43,6 +43,27 @@ void main() {
       }
     });
 
+    test('test MockDataCallback', () async {
+      var data = {
+        'id': 1,
+        'name': 'mock',
+      };
+      Response<dynamic> response;
+
+      dioAdapter.onPost(
+        path,
+        (server) => server.reply(200, data),
+        data: (options) {
+          options = options as RequestOptions;
+          return options.data;
+        },
+      );
+
+      response = await dio.post(path, data: data);
+
+      expect(data, response.data);
+    });
+
     test('throws AssertionError when unable to find mocked route', () async {
       expect(
         () async => await dio.get('/undefined'),


### PR DESCRIPTION
# Pull Request Template

## Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/lomsa-dev/http-mock-adapter/blob/develop/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a `feature`/`bugfix` branch** (right side). Don't request your `main` or `develop`!
- [ ] Make sure you are making a pull request against the **`develop` branch** (left side). Also, you should start *your branch* off *our `develop`*.
- [ ] Make sure that you add reviewers, assignees, labels, projects, milestones and linkes issues to the pull request as you see fit.
- [ ] Check the commit's or even all commits' message styles to match our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.

**Tip**: Delete everything but the following section that contains the description of the pull request.

---

## Description
For mock http request, not just for unit test. so RequestHandler.reply's parameter data should be function.
so when the real RequestOptions pass in ,the return data can be code with logic.

Please describe your pull request.

Thank you!
