### PR TITLE
new feature:  add http matchers api

### DIFF
--- a/lib/http_mock_adapter.dart
+++ b/lib/http_mock_adapter.dart
@@ -2,5 +2,6 @@ export 'src/adapters/dio_adapter.dart';
 export 'src/exceptions.dart' show MockDioError;
 export 'src/extensions/matches_request.dart';
 export 'src/interceptors/dio_interceptor.dart';
+export 'src/matchers/http_matcher.dart';
 export 'src/matchers/matchers.dart';
 export 'src/request.dart' show Request, RequestMethods;

--- a/lib/src/adapters/dio_adapter.dart
+++ b/lib/src/adapters/dio_adapter.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:http_mock_adapter/src/exceptions.dart';
+import 'package:http_mock_adapter/src/matchers/http_matcher.dart';
 import 'package:http_mock_adapter/src/mixins/mixins.dart';
 import 'package:http_mock_adapter/src/response.dart';
 
@@ -13,9 +14,13 @@ class DioAdapter extends HttpClientAdapter with Recording, RequestHandling {
   @override
   final Dio dio;
 
+  @override
+  final HttpRequestMatcher matcher;
+
   /// Constructs a [DioAdapter] and configures the passed [Dio] instance.
   DioAdapter({
     required this.dio,
+    this.matcher = const FullHttpRequestMatcher(),
   }) {
     dio.httpClientAdapter = this;
   }

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:http_mock_adapter/src/matchers/http_matcher.dart';
 import 'package:http_mock_adapter/src/mixins/mixins.dart';
 import 'package:http_mock_adapter/src/response.dart';
 
@@ -7,9 +8,13 @@ class DioInterceptor extends Interceptor with Recording, RequestHandling {
   @override
   final Dio dio;
 
+  @override
+  final HttpRequestMatcher matcher;
+
   /// Constructs a [DioInterceptor] and configures the passed [Dio] instance.
   DioInterceptor({
     required this.dio,
+    this.matcher = const FullHttpRequestMatcher(),
   }) {
     dio.interceptors.add(this);
   }

--- a/lib/src/matchers/http_matcher.dart
+++ b/lib/src/matchers/http_matcher.dart
@@ -1,0 +1,32 @@
+import 'package:dio/dio.dart';
+
+import '../../http_mock_adapter.dart';
+
+abstract class HttpRequestMatcher {
+  const HttpRequestMatcher();
+
+  bool matches(RequestOptions ongoingRequest, Request matcher);
+}
+
+class FullHttpRequestMatcher extends HttpRequestMatcher {
+  const FullHttpRequestMatcher();
+
+  @override
+  bool matches(RequestOptions ongoingRequest, Request matcher) {
+    return ongoingRequest.matchesRequest(matcher);
+  }
+}
+
+class UrlRequestMatcher extends HttpRequestMatcher {
+  final bool matchMethod;
+
+  UrlRequestMatcher({this.matchMethod = false});
+
+  @override
+  bool matches(RequestOptions ongoingRequest, Request matcher) {
+    final isRouteTheSame =
+        ongoingRequest.doesRouteMatch(ongoingRequest.path, matcher.route);
+    return isRouteTheSame &&
+        (!matchMethod || ongoingRequest.method == matcher.method?.name);
+  }
+}

--- a/lib/src/mixins/recording.dart
+++ b/lib/src/mixins/recording.dart
@@ -1,10 +1,12 @@
-import 'package:http_mock_adapter/src/extensions/matches_request.dart';
 import 'package:http_mock_adapter/src/extensions/signature.dart';
+import 'package:http_mock_adapter/src/matchers/http_matcher.dart';
 import 'package:http_mock_adapter/src/request.dart';
 import 'package:http_mock_adapter/src/types.dart';
 
 /// An ability that lets a construct to record a [RequestMatcher] history.
 mixin Recording {
+  HttpRequestMatcher get matcher;
+
   /// The index of request invocations.
   int? _invocationIndex;
 
@@ -20,7 +22,7 @@ mixin Recording {
 
         for (var requestMatcher in _requestMatchers) {
           if (requestOptions.signature == requestMatcher.request.signature ||
-              requestOptions.matchesRequest(requestMatcher.request)) {
+              matcher.matches(requestOptions, requestMatcher.request)) {
             _invocationIndex = _requestMatchers.indexOf(requestMatcher);
           }
         }


### PR DESCRIPTION

## Description

This PR externalises the matching criteria in the form of an abstract class called `HttpMatcher`.

Extracting HTTP matchers allows consumers granular control over the matching logic. The default matcher is the existing logic in the form of a `FullHttpRequestMatcher`. Users can opt for a partial `UrlRequestMatcher` instead as well.

I've also added [a detailed issue](https://github.com/lomsa-dev/http-mock-adapter/issues/124) here regarding this and another modified
Any feedback would be welcome.
