### PR TITLE
Bump to v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [v0.3.3] (2022-03-23)
+
+- **Added**
+  - `delay` property to `MockServer` methods: (reply & throws)
+  - `HttpRequestMatcher` super class & its implementations `FullHttpRequestMatcher`, `UrlRequestMatcher`.
+  -  Utilities file for tests.
+
+- **Updated**
+  - Docs in `README.md` and `example/main.dart`.
+  - Tests for `DioAdapter`.
+
 ## [v0.3.2] (2021-07-26)
 
 - **Added**

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dev_dependencies:
-  http_mock_adapter: ^0.3.2
+  http_mock_adapter: ^0.3.3
 ```
 
 #### Install it

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: http_mock_adapter
 description: A simple to use mocking package for Dio intended to be used in tests. It provides various types and methods to declaratively mock request-response communication.
-version: 0.3.2
+version: 0.3.3
 homepage: https://lomsa.com
 repository: https://github.com/lomsa-dev/http-mock-adapter
 issue_tracker: https://github.com/lomsa-dev/http-mock-adapter/issues


### PR DESCRIPTION
Updates library version to **v0.3.3** (from v0.3.2)

---

**Tested with `flutter pub publish --dry-run`**
<img width="316" alt="Screen Shot 2022-03-23 at 11 36 01" src="https://user-images.githubusercontent.com/59066341/159647361-046e10c0-af79-4196-a80b-d9e4c0dccdab.png">

**Coverage:**
<img width="316" alt="Screen Shot 2022-03-23 at 11 36 39" src="https://user-images.githubusercontent.com/59066341/159647395-f851c61f-ff81-43f2-8123-1a3903fde0b1.png">

---

### [v0.3.3] (2022-03-23)

- **Added**
  - `delay` property to `MockServer` methods: (reply & throws)
  - `HttpRequestMatcher` super class & its implementations `FullHttpRequestMatcher`, `UrlRequestMatcher`.
  -  Utilities file for tests.

- **Updated**
  - Docs in `README.md` and `example/main.dart`.
  - Tests for `DioAdapter`.

