### PR TITLE
Remove recursive export of matchers.dart

### DIFF
--- a/lib/src/matchers/matchers.dart
+++ b/lib/src/matchers/matchers.dart
@@ -14,7 +14,6 @@ import 'package:http_mock_adapter/src/matchers/regexp.dart';
 import 'package:http_mock_adapter/src/matchers/string.dart';
 
 export 'package:http_mock_adapter/src/matchers/matcher.dart';
-export 'package:http_mock_adapter/src/matchers/matchers.dart' show Matchers;
 
 /// [Matchers] is an interface for various [Matcher] types.
 abstract class Matchers {


### PR DESCRIPTION
# Pull Request Template

## Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/lomsa-dev/http-mock-adapter/blob/develop/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a `feature`/`bugfix` branch** (right side). Don't request your `main` or `develop`!
- [x] Make sure you are making a pull request against the **`develop` branch** (left side). Also, you should start *your branch* off *our `develop`*.
- [x] Make sure that you add reviewers, assignees, labels, projects, milestones and linkes issues to the pull request as you see fit.
- [x] Check the commit's or even all commits' message styles to match our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

**Tip**: Delete everything but the following section that contains the description of the pull request.

---

## Description

This pull request removes a recursive export of `matchers.dart`, since it causes [freezed](https://pub.dev/packages/freezed) to fail when generating code. See this issue for reference: https://github.com/rrousselGit/freezed/issues/445

I'm opening a new pull request since I accidentally removed the branch from my previous pull request (https://github.com/lomsa-dev/http-mock-adapter/pull/132).