### PR TITLE
Add support for replying byte data

### DIFF
--- a/lib/src/handlers/request_handler.dart
+++ b/lib/src/handlers/request_handler.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
@@ -50,6 +51,16 @@ class RequestHandler implements MockServer {
         false;
 
     mockResponse = (requestOptions) {
+      if (data is Uint8List) {
+        return MockResponseBody.fromBytes(
+          data,
+          statusCode,
+          headers: headers,
+          statusMessage: statusMessage,
+          isRedirect: isRedirect,
+          delay: delay,
+        );
+      }
       var rawData = data;
       if (data is MockDataCallback) {
         rawData = data(requestOptions);

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -43,7 +43,10 @@ class MockResponseBody extends ResponseBody implements MockResponse {
   }) =>
       MockResponseBody(
         Stream.fromIterable(
-          utf8.encode(text).map((elements) => Uint8List.fromList([elements])).toList(),
+          utf8
+              .encode(text)
+              .map((elements) => Uint8List.fromList([elements]))
+              .toList(),
         ),
         statusCode,
         headers: headers,
@@ -51,7 +54,7 @@ class MockResponseBody extends ResponseBody implements MockResponse {
         isRedirect: isRedirect,
         delay: delay,
       );
-    
+
   static MockResponseBody fromBytes(
     Uint8List bytes,
     int statusCode, {

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -43,11 +43,25 @@ class MockResponseBody extends ResponseBody implements MockResponse {
   }) =>
       MockResponseBody(
         Stream.fromIterable(
-          utf8
-              .encode(text)
-              .map((elements) => Uint8List.fromList([elements]))
-              .toList(),
+          utf8.encode(text).map((elements) => Uint8List.fromList([elements])).toList(),
         ),
+        statusCode,
+        headers: headers,
+        statusMessage: statusMessage,
+        isRedirect: isRedirect,
+        delay: delay,
+      );
+    
+  static MockResponseBody fromBytes(
+    Uint8List bytes,
+    int statusCode, {
+    required Map<String, List<String>> headers,
+    String? statusMessage,
+    required bool isRedirect,
+    Duration? delay,
+  }) =>
+      MockResponseBody(
+        Stream.value(bytes),
         statusCode,
         headers: headers,
         statusMessage: statusMessage,

--- a/test/handlers/request_handler_test.dart
+++ b/test/handlers/request_handler_test.dart
@@ -1,4 +1,6 @@
+import 'dart:ffi';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
@@ -12,6 +14,27 @@ void main() {
 
     setUp(() {
       requestHandler = RequestHandler();
+    });
+    test('sets response data for a status with Uint8List', () async {
+      const statusCode = HttpStatus.ok;
+      final inputData = Uint8List.fromList([1, 2, 3, 4, 5]);
+
+      requestHandler.reply(
+        statusCode,
+        inputData,
+      );
+
+      final statusHandler = requestHandler.mockResponse;
+
+      expect(statusHandler, isNotNull);
+
+      final mockResponseBody = statusHandler(RequestOptions(path: '')) as MockResponseBody;
+      final resolvedData = await BackgroundTransformer().transformResponse(
+        RequestOptions(path: '', responseType: ResponseType.bytes),
+        mockResponseBody,
+      );
+
+      expect(resolvedData, inputData);
     });
 
     test('sets response data for a status with JSON by default', () async {
@@ -27,8 +50,7 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockResponseBody =
-          statusHandler(RequestOptions(path: '')) as MockResponseBody;
+      final mockResponseBody = statusHandler(RequestOptions(path: '')) as MockResponseBody;
 
       final resolvedData = await BackgroundTransformer().transformResponse(
         RequestOptions(path: ''),
@@ -58,18 +80,15 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockResponseBody =
-          statusHandler(RequestOptions(path: '')) as MockResponseBody;
+      final mockResponseBody = statusHandler(RequestOptions(path: '')) as MockResponseBody;
 
-      final resolvedData = await BackgroundTransformer()
-          .transformResponse(RequestOptions(path: ''), mockResponseBody);
+      final resolvedData =
+          await BackgroundTransformer().transformResponse(RequestOptions(path: ''), mockResponseBody);
 
       expect(resolvedData, data);
     });
 
-    test(
-        'sets response data for a status without JSON if content type header is set',
-        () async {
+    test('sets response data for a status without JSON if content type header is set', () async {
       const statusCode = HttpStatus.created;
       const inputData = 'Plain text response';
       const headers = {
@@ -88,8 +107,7 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockResponseBody =
-          statusHandler(RequestOptions(path: '')) as MockResponseBody;
+      final mockResponseBody = statusHandler(RequestOptions(path: '')) as MockResponseBody;
 
       final resolvedData = await BackgroundTransformer().transformResponse(
         RequestOptions(path: ''),
@@ -118,8 +136,7 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockDioError =
-          statusHandler(RequestOptions(path: '')) as MockDioError;
+      final mockDioError = statusHandler(RequestOptions(path: '')) as MockDioError;
 
       expect(mockDioError.type, dioError.type);
     });

--- a/test/handlers/request_handler_test.dart
+++ b/test/handlers/request_handler_test.dart
@@ -28,7 +28,8 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockResponseBody = statusHandler(RequestOptions(path: '')) as MockResponseBody;
+      final mockResponseBody =
+          statusHandler(RequestOptions(path: '')) as MockResponseBody;
       final resolvedData = await BackgroundTransformer().transformResponse(
         RequestOptions(path: '', responseType: ResponseType.bytes),
         mockResponseBody,
@@ -50,7 +51,8 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockResponseBody = statusHandler(RequestOptions(path: '')) as MockResponseBody;
+      final mockResponseBody =
+          statusHandler(RequestOptions(path: '')) as MockResponseBody;
 
       final resolvedData = await BackgroundTransformer().transformResponse(
         RequestOptions(path: ''),
@@ -80,15 +82,18 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockResponseBody = statusHandler(RequestOptions(path: '')) as MockResponseBody;
+      final mockResponseBody =
+          statusHandler(RequestOptions(path: '')) as MockResponseBody;
 
-      final resolvedData =
-          await BackgroundTransformer().transformResponse(RequestOptions(path: ''), mockResponseBody);
+      final resolvedData = await BackgroundTransformer()
+          .transformResponse(RequestOptions(path: ''), mockResponseBody);
 
       expect(resolvedData, data);
     });
 
-    test('sets response data for a status without JSON if content type header is set', () async {
+    test(
+        'sets response data for a status without JSON if content type header is set',
+        () async {
       const statusCode = HttpStatus.created;
       const inputData = 'Plain text response';
       const headers = {
@@ -107,7 +112,8 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockResponseBody = statusHandler(RequestOptions(path: '')) as MockResponseBody;
+      final mockResponseBody =
+          statusHandler(RequestOptions(path: '')) as MockResponseBody;
 
       final resolvedData = await BackgroundTransformer().transformResponse(
         RequestOptions(path: ''),
@@ -136,7 +142,8 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockDioError = statusHandler(RequestOptions(path: '')) as MockDioError;
+      final mockDioError =
+          statusHandler(RequestOptions(path: '')) as MockDioError;
 
       expect(mockDioError.type, dioError.type);
     });


### PR DESCRIPTION
## Description

Response like Protocol Buffer will have byte response body.
Adding support for mock response of byte data.

- Add byte data response type upon https://github.com/lomsa-dev/http-mock-adapter/issues/107. If the data is `Uint8List`, it will use `MockResponseBody.fromBytes` instead `MockResponseBody.from`.

- Add unit tests for RequestHandler class.