### PR TITLE
Update Dio to 5.2.0

### DIFF
--- a/.github/workflows/dart-ci.yml
+++ b/.github/workflows/dart-ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [ 2.15.0, stable ]
+        sdk: [ 2.18.3, stable ]
 
     steps:
       - name: Checkout the repository

--- a/example/main.dart
+++ b/example/main.dart
@@ -78,7 +78,7 @@ void main() async {
           signInRoute,
           (server) => server.throws(
             401,
-            DioError(
+            DioException(
               requestOptions: RequestOptions(
                 path: signInRoute,
               ),
@@ -99,7 +99,7 @@ void main() async {
       // Throws without user credentials.
       expect(
         () async => await dio.post(signInRoute),
-        throwsA(isA<DioError>()),
+        throwsA(isA<DioException>()),
       );
 
       // Returns an access token if user credentials are provided.

--- a/lib/http_mock_adapter.dart
+++ b/lib/http_mock_adapter.dart
@@ -1,5 +1,5 @@
 export 'src/adapters/dio_adapter.dart';
-export 'src/exceptions.dart' show MockDioError;
+export 'src/exceptions.dart' show MockDioException;
 export 'src/extensions/matches_request.dart';
 export 'src/interceptors/dio_interceptor.dart';
 export 'src/matchers/http_matcher.dart';

--- a/lib/src/adapters/dio_adapter.dart
+++ b/lib/src/adapters/dio_adapter.dart
@@ -45,8 +45,8 @@ class DioAdapter with Recording, RequestHandling implements HttpClientAdapter {
     // Waits for defined duration.
     if (response.delay != null) await Future.delayed(response.delay!);
 
-    // Throws DioError if response type is MockDioError.
-    if (isMockDioError(response)) throw response as DioError;
+    // Throws DioException if response type is MockDioException.
+    if (isMockDioException(response)) throw response as DioException;
 
     return response as MockResponseBody;
   }

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -3,15 +3,15 @@ import 'package:http_mock_adapter/src/adapters/dio_adapter.dart';
 import 'package:http_mock_adapter/src/interceptors/dio_interceptor.dart';
 import 'package:http_mock_adapter/src/response.dart';
 
-/// Wrapper of [Dio]'s [DioError] [Exception].
-class MockDioError extends DioError implements MockResponse {
+/// Wrapper of [Dio]'s [DioException] [Exception].
+class MockDioException extends DioException implements MockResponse {
   @override
   final Duration? delay;
 
-  MockDioError({
+  MockDioException({
     required RequestOptions requestOptions,
     Response? response,
-    DioErrorType type = DioErrorType.unknown,
+    DioExceptionType type = DioExceptionType.unknown,
     dynamic error,
     this.delay,
   }) : super(
@@ -21,8 +21,8 @@ class MockDioError extends DioError implements MockResponse {
           error: error,
         );
 
-  static MockDioError from(DioError dioError, [Duration? delay]) =>
-      MockDioError(
+  static MockDioException from(DioException dioError, [Duration? delay]) =>
+      MockDioException(
         requestOptions: dioError.requestOptions,
         response: dioError.response,
         type: dioError.type,

--- a/lib/src/handlers/request_handler.dart
+++ b/lib/src/handlers/request_handler.dart
@@ -22,7 +22,7 @@ abstract class MockServer {
 
   void throws(
     int statusCode,
-    DioError dioError, {
+    DioException dioError, {
     Duration? delay,
   });
 }
@@ -77,9 +77,9 @@ class RequestHandler implements MockServer {
     };
   }
 
-  /// Stores the [DioError] inside the [mockResponse].
+  /// Stores the [DioException] inside the [mockResponse].
   @override
-  void throws(int statusCode, DioError dioError, {Duration? delay}) {
-    mockResponse = (requestOptions) => MockDioError.from(dioError, delay);
+  void throws(int statusCode, DioException dioError, {Duration? delay}) {
+    mockResponse = (requestOptions) => MockDioException.from(dioError, delay);
   }
 }

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -26,9 +26,9 @@ class DioInterceptor extends Interceptor with Recording, RequestHandling {
     await setDefaultRequestHeaders(dio, requestOptions);
     final response = mockResponse(requestOptions);
 
-    // Reject the response if type is MockDioError.
-    if (isMockDioError(response)) {
-      requestInterceptorHandler.reject(response as DioError);
+    // Reject the response if type is MockDioException.
+    if (isMockDioException(response)) {
+      requestInterceptorHandler.reject(response as DioException);
 
       return;
     }

--- a/lib/src/mixins/request_handling.dart
+++ b/lib/src/mixins/request_handling.dart
@@ -191,6 +191,6 @@ mixin RequestHandling on Recording {
         ),
       );
 
-  bool isMockDioError(MockResponse mockResponse) =>
-      mockResponse is MockDioError;
+  bool isMockDioException(MockResponse mockResponse) =>
+      mockResponse is MockDioException;
 }

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -3,8 +3,8 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 
-/// Top level interface for [Dio]'s [ResponseBody] and also [Dio]'s [DioError].
-/// This interface makes sure that we can save [DioError] and [ResponseBody]
+/// Top level interface for [Dio]'s [ResponseBody] and also [Dio]'s [DioException].
+/// This interface makes sure that we can save [DioException] and [ResponseBody]
 /// inside the same list.
 abstract class MockResponse {
   /// Delays this response by the given duration.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,14 +6,14 @@ repository: https://github.com/lomsa-dev/http-mock-adapter
 issue_tracker: https://github.com/lomsa-dev/http-mock-adapter/issues
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: '>=2.18.3 <3.0.0'
 
 dependencies:
-  collection: ^1.15.0
-  dio: ^5.0.0
+  collection: ^1.17.1
+  dio: ^5.2.1
   http_parser: ^4.0.2
 
 dev_dependencies:
   lints: '>=1.0.1'
-  test: ^1.21.0
+  test: ^1.24.3
   fake_async: ^1.3.1

--- a/test/adapters/dio_adapter_test.dart
+++ b/test/adapters/dio_adapter_test.dart
@@ -26,7 +26,7 @@ void main() {
       expect(
         () async => await dio.get('/route'),
         throwsA(predicate(
-            (DioError dioError) => dioError.error is ClosedException)),
+            (DioException dioError) => dioError.error is ClosedException)),
       );
     });
 
@@ -47,8 +47,8 @@ void main() {
 
     test('delays error', () async {
       const delay = 5000;
-      final dioError = DioError(
-        type: DioErrorType.badResponse,
+      final dioError = DioException(
+        type: DioExceptionType.badResponse,
         requestOptions: RequestOptions(path: 'path'),
       );
 
@@ -65,7 +65,7 @@ void main() {
         () async {
           try {
             await dio.get('/route');
-          } on DioError catch (_) {
+          } on DioException catch (_) {
             // Ignore expected error.
           }
         },

--- a/test/extensions/matches_request_test.dart
+++ b/test/extensions/matches_request_test.dart
@@ -246,8 +246,8 @@ void main() {
           expect(
               () => dio.get(path),
               throwsA(predicate((e) =>
-                  e is DioError &&
-                  e.type == DioErrorType.unknown &&
+                  e is DioException &&
+                  e.type == DioExceptionType.unknown &&
                   e.error is AssertionError)));
         });
       });

--- a/test/handlers/request_handler_test.dart
+++ b/test/handlers/request_handler_test.dart
@@ -123,13 +123,13 @@ void main() {
       expect(mockResponseBody.headers, headers);
     });
 
-    test('sets DioError for a status code', () async {
+    test('sets DioException for a status code', () async {
       const statusCode = HttpStatus.badRequest;
-      final dioError = DioError(
+      final dioError = DioException(
         requestOptions: RequestOptions(
           path: 'path',
         ),
-        type: DioErrorType.badResponse,
+        type: DioExceptionType.badResponse,
       );
 
       requestHandler.throws(
@@ -141,10 +141,10 @@ void main() {
 
       expect(statusHandler, isNotNull);
 
-      final mockDioError =
-          statusHandler(RequestOptions(path: '')) as MockDioError;
+      final mockDioException =
+          statusHandler(RequestOptions(path: '')) as MockDioException;
 
-      expect(mockDioError.type, dioError.type);
+      expect(mockDioException.type, dioError.type);
     });
   });
 }

--- a/test/mixins/recording_test.dart
+++ b/test/mixins/recording_test.dart
@@ -65,7 +65,8 @@ void main() {
       expect(
         () async => await dio.get('/undefined'),
         throwsA(
-          predicate((DioError dioError) => dioError.error is AssertionError),
+          predicate(
+              (DioException dioError) => dioError.error is AssertionError),
         ),
       );
     });

--- a/test/mixins/request_handling_test.dart
+++ b/test/mixins/request_handling_test.dart
@@ -122,14 +122,14 @@ void main() {
         });
 
         test('throws raises custom exception', () async {
-          final dioError = DioError(
+          final dioError = DioException(
             error: {'message': 'error'},
             requestOptions: RequestOptions(path: path),
             response: Response(
               statusCode: 500,
               requestOptions: RequestOptions(path: path),
             ),
-            type: DioErrorType.badResponse,
+            type: DioExceptionType.badResponse,
           );
 
           tester.onGet(
@@ -137,12 +137,13 @@ void main() {
             (server) => server.throws(500, dioError),
           );
 
-          expect(() async => await dio.get(path), throwsA(isA<MockDioError>()));
-          expect(() async => await dio.get(path), throwsA(isA<DioError>()));
+          expect(() async => await dio.get(path),
+              throwsA(isA<MockDioException>()));
+          expect(() async => await dio.get(path), throwsA(isA<DioException>()));
           expect(
             () async => await dio.get(path),
             throwsA(
-              predicate((DioError error) => error is MockDioError),
+              predicate((DioException error) => error is MockDioException),
             ),
           );
         });


### PR DESCRIPTION
# Update Dio to 5.2.0

## Description

Update Dio to 5.2.0.

Dio 5.2.0 introduced a renaming of DioError to DioException (see https://github.com/cfug/dio/pull/1803) which causes issues when mocking server error with DioException as http-mock-adapter currently depends on Dio 5.0.0 and as such does not know DioException.

Currently using Dio 5.2.0 with current http-mock-adapter results in a "Type not found" error.

Take the following mock:

```dart
adapter.onGet(
     url,
    (server) {
       server.throws(
           HttpStatus.continue_,
           DioException(requestOptions: RequestOptions()),
       );
   }
 },
);
```

Running this code will result in the following exception being thrown:

```shell
Error: Type 'DioException' not found.
```
