### PR TITLE
feature/add exact body check option for FullHttpRequestMatcher

### DIFF
--- a/lib/src/matchers/http_matcher.dart
+++ b/lib/src/matchers/http_matcher.dart
@@ -26,11 +26,12 @@ abstract class HttpRequestMatcher {
 /// class.
 ///
 class FullHttpRequestMatcher extends HttpRequestMatcher {
-  const FullHttpRequestMatcher();
+  final bool needsExactBody;
+  const FullHttpRequestMatcher({this.needsExactBody = false});
 
   @override
   bool matches(RequestOptions ongoingRequest, Request matcher) {
-    return ongoingRequest.matchesRequest(matcher);
+    return ongoingRequest.matchesRequest(matcher, needsExactBody);
   }
 }
 

--- a/test/extensions/matches_request_test.dart
+++ b/test/extensions/matches_request_test.dart
@@ -268,7 +268,7 @@ void main() {
             'does not match requests via onPost() when expected body is subset of actual body',
             () async {
           dioAdapter.onPost(
-            '/post-any-data',
+            '/too-many-fields',
             (server) => server.reply(200, 'OK'),
             data: {
               'expected': {
@@ -285,7 +285,7 @@ void main() {
             'unexepected': 'value'
           };
           expect(
-            () => dio.post('/post-any-data', data: data),
+            () => dio.post('/too-many-fields', data: data),
             throwsA(
               predicate((e) =>
                   e is DioException &&
@@ -298,7 +298,7 @@ void main() {
             'does not match requests via onPost() when actual body is subset of expected body',
             () async {
           dioAdapter.onPost(
-            '/post-any-data',
+            '/not-enough-fields',
             (server) => server.reply(200, 'OK'),
             data: {
               'expected': {
@@ -315,7 +315,7 @@ void main() {
             },
           };
           expect(
-            () => dio.post('/post-any-data', data: data),
+            () => dio.post('/not-enough-fields', data: data),
             throwsA(
               predicate((e) =>
                   e is DioException &&
@@ -328,7 +328,7 @@ void main() {
             'does match requests via onPost() when expected body is equal to actual body',
             () async {
           dioAdapter.onPost(
-            '/post-any-data',
+            '/post-exact-data',
             (server) => server.reply(200, 'OK'),
             data: {
               'expected': {
@@ -339,7 +339,7 @@ void main() {
             },
           );
 
-          var response = await dio.post('/post-any-data', data: {
+          var response = await dio.post('/post-exact-data', data: {
             'expected': {
               'nestedExpected': 'value',
               'nestedUnexpected': 'value',

--- a/test/extensions/matches_request_test.dart
+++ b/test/extensions/matches_request_test.dart
@@ -21,7 +21,7 @@ void main() {
         queryParameters: <String, dynamic>{},
       );
 
-      expect(options.matchesRequest(request), true);
+      expect(options.matchesRequest(request, false), true);
     });
 
     group('matches', () {
@@ -249,6 +249,105 @@ void main() {
                   e is DioException &&
                   e.type == DioExceptionType.unknown &&
                   e.error is AssertionError)));
+        });
+      });
+
+      group('Exact body matches', () {
+        late Dio dio;
+        late DioAdapter dioAdapter;
+
+        setUpAll(() {
+          dio = Dio(BaseOptions(contentType: Headers.jsonContentType));
+          dioAdapter = DioAdapter(
+            dio: dio,
+            matcher: const FullHttpRequestMatcher(needsExactBody: true),
+          );
+        });
+
+        test(
+            'does not match requests via onPost() when expected body is subset of actual body',
+            () async {
+          dioAdapter.onPost(
+            '/post-any-data',
+            (server) => server.reply(200, 'OK'),
+            data: {
+              'expected': {
+                'nestedExpected': 'value',
+              },
+            },
+          );
+
+          final data = {
+            'expected': {
+              'nestedExpected': 'value',
+              'nestedUnexpected': 'value',
+            },
+            'unexepected': 'value'
+          };
+          expect(
+            () => dio.post('/post-any-data', data: data),
+            throwsA(
+              predicate((e) =>
+                  e is DioException &&
+                  e.type == DioExceptionType.unknown &&
+                  e.error is AssertionError),
+            ),
+          );
+        });
+        test(
+            'does not match requests via onPost() when actual body is subset of expected body',
+            () async {
+          dioAdapter.onPost(
+            '/post-any-data',
+            (server) => server.reply(200, 'OK'),
+            data: {
+              'expected': {
+                'nestedExpected': 'value',
+                'nestedUnexpected': 'value',
+              },
+              'unexepected': 'value'
+            },
+          );
+
+          final data = {
+            'expected': {
+              'nestedExpected': 'value',
+            },
+          };
+          expect(
+            () => dio.post('/post-any-data', data: data),
+            throwsA(
+              predicate((e) =>
+                  e is DioException &&
+                  e.type == DioExceptionType.unknown &&
+                  e.error is AssertionError),
+            ),
+          );
+        });
+        test(
+            'does match requests via onPost() when expected body is equal to actual body',
+            () async {
+          dioAdapter.onPost(
+            '/post-any-data',
+            (server) => server.reply(200, 'OK'),
+            data: {
+              'expected': {
+                'nestedExpected': 'value',
+                'nestedUnexpected': 'value',
+              },
+              'unexepected': 'value'
+            },
+          );
+
+          var response = await dio.post('/post-any-data', data: {
+            'expected': {
+              'nestedExpected': 'value',
+              'nestedUnexpected': 'value',
+            },
+            'unexepected': 'value'
+          });
+
+          expect(response.data, 'OK');
         });
       });
     });


### PR DESCRIPTION
This PR introduces the ability to require exact body matches in cases of `Map`s when using the `FullHttpRequestMatcher` and aims to solve issue #149. 

When initiating the `DioAdapter` it can be specified to use `FullHttpRequestMatcher(needsExactBody: true)` as `matcher` parameter. If no value for `needsExactyBody` is provided then `false` will be used for default for backwards compatibility. 

Additional tests can be found in `test/extensions/matches_request_test.dart`. 